### PR TITLE
Bound stream computed field with physical limits

### DIFF
--- a/miniscope_io/data/config/WLMS_v02_200px.yml
+++ b/miniscope_io/data/config/WLMS_v02_200px.yml
@@ -34,6 +34,8 @@ adc_scale:
   bitdepth: 8
   battery_div_factor: 5
   vin_div_factor: 11.3
+  battery_max_voltage: 10.0
+  vin_max_voltage: 20.0
 
 runtime:
   serial_buffer_queue_size: 10

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -38,12 +38,12 @@ class ADCScaling(MiniscopeConfig):
     battery_max_voltage: float = Field(
         10.0,
         description="Maximum voltage of the battery."
-          "Scaled battery voltage will be 0 if it is greater than this value",
+        "Scaled battery voltage will be 0 if it is greater than this value",
     )
     vin_max_voltage: float = Field(
         20.0,
         description="Maximum voltage of the Vin"
-          "Scaled Vin voltage will be 0 if it is greater than this value",
+        "Scaled Vin voltage will be 0 if it is greater than this value",
     )
 
     def scale_battery_voltage(self, voltage_raw: float) -> float:

--- a/miniscope_io/models/stream.py
+++ b/miniscope_io/models/stream.py
@@ -35,6 +35,16 @@ class ADCScaling(MiniscopeConfig):
         11.3,
         description="Voltage divider factor for the Vin voltage",
     )
+    battery_max_voltage: float = Field(
+        10.0,
+        description="Maximum voltage of the battery."
+          "Scaled battery voltage will be 0 if it is greater than this value",
+    )
+    vin_max_voltage: float = Field(
+        20.0,
+        description="Maximum voltage of the Vin"
+          "Scaled Vin voltage will be 0 if it is greater than this value",
+    )
 
     def scale_battery_voltage(self, voltage_raw: float) -> float:
         """
@@ -113,7 +123,8 @@ class StreamBufferHeader(BufferHeader):
         if self._adc_scaling is None:
             return self.battery_voltage_raw
         else:
-            return self._adc_scaling.scale_battery_voltage(self.battery_voltage_raw)
+            battery_voltage = self._adc_scaling.scale_battery_voltage(self.battery_voltage_raw)
+            return battery_voltage if battery_voltage < self._adc_scaling.battery_max_voltage else 0
 
     @computed_field
     def input_voltage(self) -> float:
@@ -123,7 +134,8 @@ class StreamBufferHeader(BufferHeader):
         if self._adc_scaling is None:
             return self.input_voltage_raw
         else:
-            return self._adc_scaling.scale_input_voltage(self.input_voltage_raw)
+            vin_voltage = self._adc_scaling.scale_input_voltage(self.input_voltage_raw)
+            return vin_voltage if vin_voltage < self._adc_scaling.vin_max_voltage else 0
 
 
 class StreamDevRuntime(MiniscopeConfig):

--- a/tests/test_models/test_model_stream.py
+++ b/tests/test_models/test_model_stream.py
@@ -57,8 +57,8 @@ def test_adc_scaling(scale, config_override):
     example = config_override(CONFIG_DIR / "stream_daq_test_200px.yml", {"adc_scale": adc_scale})
     instance_config = StreamDevConfig.from_yaml(example)
 
-    battery_voltage_raw = 200
-    input_voltage_raw = 250
+    battery_voltage_raw = 100
+    input_voltage_raw = 150
 
     instance_header = StreamBufferHeader(
         linked_list=0,


### PR DESCRIPTION
- Sets limits on the computed ADC voltage value.
- The computed voltage is set to zero if it exceeds the limits.
- This doesn't affect the raw metadata value.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--82.org.readthedocs.build/en/82/

<!-- readthedocs-preview miniscope-io end -->