### PR TITLE
[chore] Bump to v0.6, changelog

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "mio"
+          project-slug: "miniscope-io"

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -2,4 +2,5 @@
 
 ```{click} mio.cli.config:config
 :prog: mio config
+:nested: full
 ```

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -1,6 +1,9 @@
 # `config`
 
-```{click} mio.cli.config:config
-:prog: mio config
-:nested: full
+See also: [config guide](../guide/config.md)
+
+```{eval-rst}
+.. click:: mio.cli.config:config
+    :prog: mio config
+    :nested: full
 ```

--- a/docs/cli/device.md
+++ b/docs/cli/device.md
@@ -1,0 +1,6 @@
+# `device`
+
+```{eval-rst}
+.. click:: mio.cli.main:device
+    :prog: mio device
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,7 +1,10 @@
 # CLI Usage
 
 ```{toctree}
+:maxdepth: 1
+
 config
+device
 stream
 update
 ```
@@ -10,7 +13,7 @@ Refer to the following page for details regarding ``stream_daq`` device config f
 
 - [stream_daq](../api/stream_daq.md)
 
-```{click} mio.cli.main:cli
-:prog: mio
-:nested: full
+```{eval-rst}
+.. click:: mio.cli.main:cli
+    :prog: mio
 ```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -8,8 +8,9 @@ update
 
 Refer to the following page for details regarding ``stream_daq`` device config files.
 
-- `stream_daq <../api/stream_daq.html>`_
+- [stream_daq](../api/stream_daq.md)
 
-.. click:: mio.cli.main:cli
-   :prog: mio
-   :nested: full
+```{click} mio.cli.main:cli
+:prog: mio
+:nested: full
+```

--- a/docs/cli/stream.md
+++ b/docs/cli/stream.md
@@ -1,5 +1,7 @@
 # `stream`
 
-```{click} mio.cli.stream:stream
-:prog: mio stream
+```{eval-rst}
+.. click:: mio.cli.stream:stream
+    :prog: mio stream
+    :nested: full
 ```

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -1,5 +1,7 @@
 # `update`
 
-```{click} mio.cli.update:update
-:prog: mio update
+```{eval-rst}
+.. click:: mio.cli.update:update
+    :prog: mio update
+    :nested: full
 ```

--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 0.6 - Becoming `mio`
+
+### 0.6.0 - 24-12-10
+
+#### Breaking Changes
+
+- `miniscope-io` is now known as `mio`! Big thanks to [`@heuer`](https://github.com/Aharoni-Lab/mio/issues/77)
+  for graciously giving us the name. This gives us a nice, short name that is uniform
+  across pypi, the repository, and the cli.
+- The {meth}`mio.models.config.LogConfig.level_file` and {meth}`mio.models.config.LogConfig.level_stdout`
+  fields are no longer automatically populated from the `level` field. 
+  This was because of the way the multi-source config system propagates values between
+  sources with different priorities. Now downstream consumers should check if these values
+  are `None` and use the `level` field if so. 
+
+#### Config
+
+Two big changes to config:
+
+- [`#72`](https://github.com/Aharoni-Lab/mio/pull/72) - `@sneakers-the-rat` - Global config, user config
+  from multiple sources: see the [config](../guide/config.md) documentation for more
+- [`#76`](https://github.com/Aharoni-Lab/mio/pull/76) - `@sneakers-the-rat` - Convert `formats` to `yaml`.
+  We finally got rid of the godforsaken self-inflicted wound of having instantiated models
+  serve as config, and instead are using `yaml` everywhere for static config. This includes
+  every yaml-able config having a header that indicates which model the config corresponds to,
+  a (locally) unique id, which can be used anywhere a path can be, and a version stamp in anticipation
+  of being able to handle model migrations.
+
+#### CI
+
+- [`#75`](https://github.com/Aharoni-Lab/mio/pull/75) - `@sneakers-the-rat` - Test docs builds on PRs
+  to avoid broken links and references
+
 ## 0.5
 
 ### 0.5.0 - 24-11-11


### PR DESCRIPTION
Just a minor PR to update the changelog before I push v0.6 and push our first release as `mio` :)

<!-- readthedocs-preview mio start -->
----
📚 Documentation preview 📚: https://mio--87.org.readthedocs.build/en/87/

<!-- readthedocs-preview mio end -->