### PR TITLE
Added info about what id is for device config about YAML for CLI

### DIFF
--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -26,7 +26,8 @@ def _common_options(fn: Callable) -> Callable:
         "--device_config",
         required=True,
         help=(
-            "Either a config `id` or a path to device config YAML file for streamDaq "
+            "Either a config `id` or a path to device config YAML file for streamDaq. "
+            "This is currently the id located in the first line of the YAML config file "
             "(see models.stream.StreamDevConfig). If path is relative, treated as "
             "relative to the current directory, and then if no matching file is found, "
             "relative to the user `config_dir` (see `mio config --help`)."

--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -27,7 +27,7 @@ def _common_options(fn: Callable) -> Callable:
         required=True,
         help=(
             "Either a config `id` or a path to device config YAML file for streamDaq. "
-            "This is currently the id located in the first line of the YAML config file "
+            "If you aren't using `id` you can ignore them."
             "(see models.stream.StreamDevConfig). If path is relative, treated as "
             "relative to the current directory, and then if no matching file is found, "
             "relative to the user `config_dir` (see `mio config --help`)."


### PR DESCRIPTION
Added description to device config id in stream.py about id for CLI            "This is currently the id located in the first line of the YAML config file "


<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--88.org.readthedocs.build/en/88/

<!-- readthedocs-preview miniscope-io end -->