### PR TITLE
changed gradient method to start with 1st frame

### DIFF
--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -162,12 +162,12 @@ class NoisePatchProcessor(BaseVideoProcessor):
 
         if self.noise_patch_config.enable:
             if self.noise_patch_config.method == "gradient":
-            # For the gradient method, analyze the first frame immediately
+                # For the gradient method, analyze the first frame immediately
                 broken, noise_patch = self.noise_detect_helper.detect_frame_with_noisy_buffer(
-                input_frame,
-                None,  # No previous frame needed for gradient method
-                self.noise_patch_config,
-            )
+                    input_frame,
+                    None,  # No previous frame needed for gradient method
+                    self.noise_patch_config,
+                )
             else:
                 # For the mean method, wait until the second frame to start analysis
                 if self.previous_frame is not None:
@@ -175,13 +175,12 @@ class NoisePatchProcessor(BaseVideoProcessor):
                         input_frame,
                         self.previous_frame,
                         self.noise_patch_config,
-                )
+                    )
                 else:
                     # If it's the first frame and the method is mean_error, just store the frame
                     self.previous_frame = input_frame
                     self.append_output_frame(input_frame)
                     return input_frame
-                
 
             # Handle noisy frames
             if not broken:


### PR DESCRIPTION
changed detect_frame_with_noisy_buffer in video.py

If the method is "gradient", the detect_frame_with_noisy_buffer method is called immediately on the first frame, without needing a previous frame
1st frame in a video was previously skipped, which is fine for the mean method since it needs a previous frame

was important since I also implemented a test where the 1st frame has a broken buffer and this could not be detected earlier

gradient method first frame processed:
<img width="1192" alt="Screenshot 2025-01-29 at 4 21 39 PM" src="https://github.com/user-attachments/assets/d0ec4b1f-4101-49a3-9fea-c2123530c442" />



mean method first frame skipped:
<img width="1192" alt="Screenshot 2025-01-29 at 4 21 25 PM" src="https://github.com/user-attachments/assets/273027f2-cdd4-4a56-bb3f-971e89b660ae" />


<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--98.org.readthedocs.build/en/98/

<!-- readthedocs-preview miniscope-io end -->