### PR TITLE
Combined detector / black area detector / bugfix process frame index

### DIFF
--- a/docs/api/preprocessing_guide.md
+++ b/docs/api/preprocessing_guide.md
@@ -1,4 +1,4 @@
-# preprocessing video files
+# Preprocessing videos
 
 
 ## Filtering of frames with broken buffers (blocks of a frame) 

--- a/docs/api/process/frame_helper.md
+++ b/docs/api/process/frame_helper.md
@@ -1,0 +1,7 @@
+# Frame helpers
+
+```{eval-rst}
+.. automodule:: mio.process.frame_helper
+    :members:
+    :private-members:
+```

--- a/docs/api/process/index.md
+++ b/docs/api/process/index.md
@@ -1,0 +1,9 @@
+# preprocess
+
+```{toctree}
+:caption: Preprocess
+
+video
+frame_helper
+zstack_helper
+```

--- a/docs/api/process/video.md
+++ b/docs/api/process/video.md
@@ -1,0 +1,7 @@
+# Video preprocessor
+
+```{eval-rst}
+.. automodule:: mio.process.video
+    :members:
+    :private-members:
+```

--- a/docs/api/process/zstack_helper.md
+++ b/docs/api/process/zstack_helper.md
@@ -1,0 +1,7 @@
+# z-stack helpers
+
+```{eval-rst}
+.. automodule:: mio.process.zstack_helper
+    :members:
+    :private-members:
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,6 +9,7 @@ Generic I/O interfaces for miniscopes :)
 guide/installation
 guide/config
 cli/index
+api/preprocessing_guide
 ```
 
 ```{toctree}
@@ -31,9 +32,9 @@ api/exceptions
 api/plots/index
 api/utils
 api/stream_daq
-api/preprocessing
 api/bit_operation
 api/vendor/index
+api/process/index
 ```
 
 ```{toctree}

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -3,6 +3,14 @@ mio_model: mio.models.process.DenoiseConfig
 mio_version: 0.6.1
 noise_patch:
   enable: true
+  method: gradient #gradient or mean_error or black_pixels
+  additional_methods:
+    - black_pixels
+  threshold: 20 #for first method
+  black_pixel_consecutive_threshold: 5 # If 5 consecutive pixels in a row are black, discard the frame
+  black_pixel_value_threshold: 16 # Any pixel value ≤ 16 is considered "black"
+  buffer_size: 5032
+  buffer_split: 8
   method: gradient # gradient or mean_error
   threshold: 20
   device_config_id: wireless-200px

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -3,15 +3,12 @@ mio_model: mio.models.process.DenoiseConfig
 mio_version: 0.6.1
 noise_patch:
   enable: true
-  method: gradient #gradient or mean_error or black_pixels
-  additional_methods:
-    - black_pixels
+  method: [gradient, black_area]
   threshold: 20 #for first method
   black_pixel_consecutive_threshold: 5 # If 5 consecutive pixels in a row are black, discard the frame
   black_pixel_value_threshold: 16 # Any pixel value ≤ 16 is considered "black"
   buffer_size: 5032
   buffer_split: 8
-  method: gradient # gradient or mean_error
   threshold: 20
   device_config_id: wireless-200px
   comparison_unit: 1000

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -4,15 +4,17 @@ mio_version: 0.6.1
 noise_patch:
   enable: true
   method: [gradient, black_area]
-  threshold: 20 #for first method
-  black_pixel_consecutive_threshold: 5 # If 5 consecutive pixels in a row are black, discard the frame
-  black_pixel_value_threshold: 16 # Any pixel value ≤ 16 is considered "black"
-  buffer_size: 5032
-  buffer_split: 8
-  threshold: 20
-  device_config_id: wireless-200px
-  comparison_unit: 1000
-  diff_multiply: 1
+  mean_error_config:
+    threshold: 40
+    device_config_id: wireless-200px
+    buffer_split: 8
+    comparison_unit: 1000
+    diff_multiply: 1
+  gradient_config:
+    threshold: 20
+  black_area_config:
+    consecutive_threshold: 5
+    value_threshold: 16
   output_result: true
   output_noise_patch: true
   output_diff: true

--- a/mio/data/config/process/denoise_example_mean_error.yml
+++ b/mio/data/config/process/denoise_example_mean_error.yml
@@ -4,10 +4,17 @@ mio_version: 0.6.1
 noise_patch:
   enable: true
   method: [mean_error]
-  threshold: 40
-  device_config_id: wireless-200px
-  comparison_unit: 1000
-  diff_multiply: 1
+  mean_error_config:
+    threshold: 40
+    device_config_id: wireless-200px
+    buffer_split: 8
+    comparison_unit: 1000
+    diff_multiply: 1
+  gradient_config:
+    threshold: 20
+  black_area_config:
+    consecutive_threshold: 5
+    value_threshold: 16
   output_result: true
   output_noise_patch: true
   output_diff: true

--- a/mio/data/config/process/denoise_example_mean_error.yml
+++ b/mio/data/config/process/denoise_example_mean_error.yml
@@ -3,7 +3,7 @@ mio_model: mio.models.process.DenoiseConfig
 mio_version: 0.6.1
 noise_patch:
   enable: true
-  method: mean_error
+  method: [mean_error]
   threshold: 40
   device_config_id: wireless-200px
   comparison_unit: 1000

--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -2,7 +2,7 @@
 Module for preprocessing data.
 """
 
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -48,16 +48,12 @@ class NoisePatchConfig(BaseModel):
         default=True,
         description="Enable patch based noise handling.",
     )
-    method: Literal["mean_error", "gradient"] = Field(
+    method: List[Literal["mean_error", "gradient", "black_area"]] = Field(
         default="gradient",
         description="Method for detecting noise."
-        "The gradient method is the current recommended method."
         "gradient: Detection based on the gradient of the frame row."
-        "mean_error: Detection based on the mean error with the same row of the previous frame.",
-    )
-    additional_methods: Optional[list[str]] = Field(
-        default=list,
-        description="Additional noise detection methods to apply after the primary method.",
+        "mean_error: Detection based on the mean error with the same row of the previous frame."
+        "black_area: Detection based on the number of consecutive black pixels in a row.",
     )
     threshold: float = Field(
         default=20,

--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -2,7 +2,7 @@
 Module for preprocessing data.
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel, Field
 
@@ -70,6 +70,7 @@ class NoisePatchConfig(BaseModel):
         description="ID of the stream device configuration used for aquiring the video."
         "This is used in the mean_error method to compare frames"
         " in the units of data transfer buffers.",
+    )
     black_pixel_consecutive_threshold: int = Field(
         default=5,
         description="Number of consecutive black pixels required to classify a row as noisy.",

--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -2,7 +2,7 @@
 Module for preprocessing data.
 """
 
-from typing import Literal, Optional
+from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -55,6 +55,10 @@ class NoisePatchConfig(BaseModel):
         "gradient: Detection based on the gradient of the frame row."
         "mean_error: Detection based on the mean error with the same row of the previous frame.",
     )
+    additional_methods: Optional[list[str]] = Field(
+        default=list,
+        description="Additional noise detection methods to apply after the primary method.",
+    )
     threshold: float = Field(
         default=20,
         description="Threshold for detecting noise."
@@ -66,6 +70,18 @@ class NoisePatchConfig(BaseModel):
         description="ID of the stream device configuration used for aquiring the video."
         "This is used in the mean_error method to compare frames"
         " in the units of data transfer buffers.",
+    black_pixel_consecutive_threshold: int = Field(
+        default=5,
+        description="Number of consecutive black pixels required to classify a row as noisy.",
+    )
+    black_pixel_value_threshold: int = Field(
+        default=20,
+        description="Pixel intensity value below which a pixel is considered 'black'.",
+    )
+    buffer_size: int = Field(
+        default=5032,
+        description="Size of the buffers composing the image."
+        "This premises that the noisy area will appear in units of buffer_size.",
     )
     buffer_split: int = Field(
         default=1,

--- a/mio/process/frame_helper.py
+++ b/mio/process/frame_helper.py
@@ -56,44 +56,49 @@ class NoiseDetectionHelper:
             )
         logger.debug(f"Buffer size: {px_per_buffer}")
 
-        if config.method == "mean_error":
-            if previous_frame is None:
-                raise ValueError("mean_error requires a previous frame to compare against")
-            return self._detect_with_mean_error(
-                current_frame=current_frame,
-                previous_frame=previous_frame,
-                config=config,
-            )
+        methods = [config.method]
+        if hasattr(config, "additional_methods") and isinstance(config.additional_methods, list):
+            methods.extend(config.additional_methods)
 
-        elif config.method == "gradient":
-            return self._detect_with_gradient(current_frame, config)
-        else:
-            logger.error(f"Unsupported noise detection method: {config.method}")
-            raise ValueError(f"Unsupported noise detection method: {config.method}")
+        logger.debug(f"Applying noise detection methods: {methods}")
 
-    def _get_buffer_shape(
-        self, frame_width: int, frame_height: int, px_per_buffer: int
-    ) -> list[int]:
-        """
-        Get the shape of each buffer in a frame.
+        noisy_flag = False
+        combined_mask = np.zeros_like(current_frame, dtype=np.uint8)
 
-        Parameters:
-            frame_width (int): The width of the frame.
-            frame_height (int): The height of the frame.
-            px_per_buffer (int): The number of pixels per buffer.
+        for method in methods:
+            if method == "mean_error":
+                if previous_frame is None:
+                    raise ValueError("mean_error requires a previous frame to compare against")
 
-        Returns:
-            list[int]: The shape of each buffer in the frame.
-        """
-        buffer_shape = []
+                serialized_current = current_frame.flatten().astype(np.int16)
+                serialized_previous = previous_frame.flatten().astype(np.int16)
 
-        pixel_index = 0
-        while pixel_index < frame_width * frame_height:
-            buffer_shape.append(int(pixel_index))
-            pixel_index += px_per_buffer
-        logger.debug(f"Split shape: {buffer_shape}")
+                split_size = config.buffer_size // config.buffer_split + 1
+                split_previous = self.split_by_length(serialized_previous, split_size)
+                split_current = self.split_by_length(serialized_current, split_size)
 
-        return buffer_shape
+                noisy, mask = self._detect_with_mean_error(split_current, split_previous, config)
+
+            elif method == "gradient":
+                noisy, mask = self._detect_with_gradient(current_frame, config)
+
+            elif method == "black_pixels":
+                noisy, mask = self._detect_black_pixels(current_frame, config)
+
+            else:
+                logger.error(f"Unsupported noise detection method: {method}")
+                continue  # Skip unknown methods
+
+            if noisy:
+                logger.info(f"Frame detected as noisy using method: {method}")
+            else:
+                logger.debug(f"Frame passed as clean using method: {method}")
+
+            # Combine results
+            noisy_flag = noisy_flag or noisy
+            combined_mask = np.maximum(combined_mask, mask)
+
+        return noisy_flag, combined_mask
 
     def _detect_with_mean_error(
         self,
@@ -171,6 +176,55 @@ class NoiseDetectionHelper:
 
         # Determine if the frame is noisy (if any rows are marked as noisy)
         frame_is_noisy = noisy_mask.any()
+
+        return frame_is_noisy, noisy_mask
+
+    def _detect_black_pixels(
+        self,
+        current_frame: np.ndarray,
+        config: NoisePatchConfig,
+    ) -> Tuple[bool, np.ndarray]:
+        """
+        Detect black-out noise by checking for black pixels (value 0) over rows of pixels.
+
+        Returns:
+            Tuple[bool, np.ndarray]: A boolean indicating if the frame is corrupted and noise mask.
+        """
+        height, width = current_frame.shape
+        noisy_mask = np.zeros_like(current_frame, dtype=np.uint8)
+
+        # Read values from YAML config
+        consecutive_threshold = (
+            config.black_pixel_consecutive_threshold
+        )  # How many consecutive pixels must be black
+        black_pixel_value_threshold = (
+            config.black_pixel_value_threshold
+        )  # Max pixel value considered "black"
+
+        logger.debug(f"Using black pixel threshold: <= {black_pixel_value_threshold}")
+        logger.debug(f"Consecutive black pixel threshold: {consecutive_threshold}")
+
+        frame_is_noisy = False  # Track if frame should be discarded
+
+        for y in range(height):
+            row = current_frame[y, :]  # Extract row
+            consecutive_count = 0  # Counter for consecutive black pixels
+
+            for x in range(width):
+                if row[x] <= black_pixel_value_threshold:  # Check if pixel is "black"
+                    consecutive_count += 1
+                else:
+                    consecutive_count = 0  # Reset if a non-black pixel is found
+
+                # If we exceed the allowed threshold of consecutive black pixels, discard the frame
+                if consecutive_count >= consecutive_threshold:
+                    logger.debug(
+                        f"Frame noisy due to {consecutive_count} consecutive black pixels "
+                        f"in row {y}."
+                    )
+                    noisy_mask[y, :] = 1  # Mark row as noisy
+                    frame_is_noisy = True
+                    break  # No need to check further in this row
 
         return frame_is_noisy, noisy_mask
 

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -162,12 +162,12 @@ class NoisePatchProcessor(BaseVideoProcessor):
 
         if self.noise_patch_config.enable:
             if self.noise_patch_config.method == "gradient":
-            # For the gradient method, analyze the first frame immediately
+                # For the gradient method, analyze the first frame immediately
                 broken, noise_patch = self.noise_detect_helper.detect_frame_with_noisy_buffer(
-                input_frame,
-                None,  # No previous frame needed for gradient method
-                self.noise_patch_config,
-            )
+                    input_frame,
+                    None,  # No previous frame needed for gradient method
+                    self.noise_patch_config,
+                )
             else:
                 # For the mean method, wait until the second frame to start analysis
                 if self.previous_frame is not None:
@@ -175,13 +175,12 @@ class NoisePatchProcessor(BaseVideoProcessor):
                         input_frame,
                         self.previous_frame,
                         self.noise_patch_config,
-                )
+                    )
                 else:
                     # If it's the first frame and the method is mean_error, just store the frame
                     self.previous_frame = input_frame
                     self.append_output_frame(input_frame)
                     return input_frame
-                
 
             # Handle noisy frames
             if not broken:

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -18,7 +18,8 @@ from mio.models.process import (
     NoisePatchConfig,
 )
 from mio.plots.video import VideoPlotter
-from mio.process.frame_helper import CombinedNoiseDetector, FrequencyMaskHelper, ZStackHelper
+from mio.process.frame_helper import CombinedNoiseDetector, FrequencyMaskHelper
+from mio.process.zstack_helper import ZStackHelper
 
 logger = init_logger("video")
 
@@ -161,7 +162,7 @@ class NoisePatchProcessor(BaseVideoProcessor):
             return None
 
         if self.noise_patch_config.enable:
-            broken, noise_patch = self.noise_detect_helper.process_and_verify_frame(input_frame)
+            broken, noise_patch = self.noise_detect_helper.find_invalid_area(input_frame)
 
             # Handle noisy frames
             if not broken:

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -308,8 +308,10 @@ class FreqencyMaskProcessor(BaseVideoProcessor):
         freq_mask_config (FreqencyMaskingConfig): The frequency masking configuration.
         """
         super().__init__(name, output_dir)
-        self.freq_mask_helper = FrequencyMaskHelper()
         self.freq_mask_config: FreqencyMaskingConfig = freq_mask_config
+        self.freq_mask_helper = FrequencyMaskHelper(
+            height=height, width=width, freq_mask_config=freq_mask_config
+        )
         self.freq_domain_frames = []
         self._freq_mask: np.ndarray = None
         self.frame_width: int = width
@@ -322,11 +324,7 @@ class FreqencyMaskProcessor(BaseVideoProcessor):
         Get the frequency mask.
         """
         if self._freq_mask is None:
-            self._freq_mask = self.freq_mask_helper.gen_freq_mask(
-                freq_mask_config=self.freq_mask_config,
-                width=self.frame_width,
-                height=self.frame_height,
-            )
+            self._freq_mask = self.freq_mask_helper.freq_mask
         return self._freq_mask
 
     @property
@@ -357,10 +355,8 @@ class FreqencyMaskProcessor(BaseVideoProcessor):
         if input_frame is None:
             return None
         if self.freq_mask_config.enable:
-            freq_filtered_frame, frame_freq_domain = self.freq_mask_helper.apply_freq_mask(
-                img=input_frame,
-                mask=self.freq_mask,
-            )
+            freq_filtered_frame = self.freq_mask_helper.process_frame(img=input_frame)
+            frame_freq_domain = self.freq_mask_helper.freq_domain(img=input_frame)
             self.append_output_frame(freq_filtered_frame)
             self.freq_domain_frames.append(frame_freq_domain)
 

--- a/mio/process/zstack_helper.py
+++ b/mio/process/zstack_helper.py
@@ -1,0 +1,65 @@
+"""
+Helper module for Z-stack operations.
+"""
+
+import cv2
+import numpy as np
+
+
+class ZStackHelper:
+    """
+    Helper class for Z-stack operations.
+    """
+
+    @staticmethod
+    def get_minimum_projection(image_list: list[np.ndarray]) -> np.ndarray:
+        """
+        Get the minimum projection of a list of images.
+
+        Parameters:
+            image_list (list[np.ndarray]): A list of images to project.
+
+        Returns:
+            np.ndarray: The minimum projection of the images.
+        """
+        stacked_images = np.stack(image_list, axis=0)
+        min_projection = np.min(stacked_images, axis=0)
+        return min_projection
+
+    @staticmethod
+    def normalize_video_stack(image_list: list[np.ndarray]) -> list[np.ndarray]:
+        """
+        Normalize a stack of images to 0-255 using max and minimum values of the entire stack.
+        Return a list of images.
+
+        Parameters:
+            image_list (list[np.ndarray]): A list of images to normalize.
+
+        Returns:
+            list[np.ndarray]: The normalized images as a list.
+        """
+
+        # Stack images along a new axis (axis=0)
+        stacked_images = np.stack(image_list, axis=0)
+
+        # Find the global min and max across the entire stack
+        global_min = stacked_images.min()
+        global_max = stacked_images.max()
+
+        range_val = max(global_max - global_min, 1e-5)  # Set an epsilon value for stability
+
+        # Normalize each frame using the global min and max
+        normalized_images = []
+        for i in range(stacked_images.shape[0]):
+            normalized_image = cv2.normalize(
+                stacked_images[i],
+                None,
+                0,
+                np.iinfo(np.uint8).max,
+                cv2.NORM_MINMAX,
+                dtype=cv2.CV_32F,
+            )
+            normalized_image = (stacked_images[i] - global_min) / range_val * np.iinfo(np.uint8).max
+            normalized_images.append(normalized_image.astype(np.uint8))
+
+        return normalized_images

--- a/tests/test_process/test_frame_helper.py
+++ b/tests/test_process/test_frame_helper.py
@@ -53,7 +53,7 @@ class NoiseGroundTruth(BaseModel):
         ("mean_error", GroundTruthCategory.check_pattern),
     ],
 )
-def test_noise_detection_contrast(video, ground_truth, noise_detection_method, noise_category):
+def test_noisy_frame_detection(video, ground_truth, noise_detection_method, noise_category):
     """
     Contrast method of noise detection should correctly label frames corrupted
     by speckled noise

--- a/tests/test_process/test_frame_helper.py
+++ b/tests/test_process/test_frame_helper.py
@@ -8,7 +8,7 @@ from pprint import pformat
 from pydantic import BaseModel
 
 from mio.models.process import DenoiseConfig, NoisePatchConfig
-from mio.process.frame_helper import NoiseDetectionHelper
+from mio.process.frame_helper import CombinedNoiseDetector
 
 from ..conftest import DATA_DIR
 
@@ -82,10 +82,7 @@ def test_noisy_frame_detection(video, ground_truth, noise_detection_method, nois
 
     video = cv2.VideoCapture(video)
 
-    detector = NoiseDetectionHelper(
-        height=int(video.get(cv2.CAP_PROP_FRAME_HEIGHT)),
-        width=int(video.get(cv2.CAP_PROP_FRAME_WIDTH)),
-    )
+    detector = CombinedNoiseDetector(noise_patch_config=config)
 
     detected_frames = []
     previous_frame = None
@@ -98,9 +95,7 @@ def test_noisy_frame_detection(video, ground_truth, noise_detection_method, nois
         if previous_frame is None:
             previous_frame = frame
 
-        is_noisy, mask = detector.detect_frame_with_noisy_buffer(
-            current_frame=frame, previous_frame=previous_frame, config=config
-        )
+        is_noisy, mask = detector.process_and_verify_frame(frame=frame)
         if not is_noisy:
             previous_frame = frame
 

--- a/tests/test_process/test_frame_helper.py
+++ b/tests/test_process/test_frame_helper.py
@@ -49,6 +49,7 @@ class NoiseGroundTruth(BaseModel):
     "noise_detection_method,noise_category",
     [
         ("gradient", GroundTruthCategory.check_pattern),
+        ("gradient", GroundTruthCategory.blacked_out),
         ("mean_error", GroundTruthCategory.check_pattern),
     ],
 )

--- a/tests/test_process/test_frame_helper.py
+++ b/tests/test_process/test_frame_helper.py
@@ -49,7 +49,7 @@ class NoiseGroundTruth(BaseModel):
     "noise_detection_method,noise_category",
     [
         ("gradient", GroundTruthCategory.check_pattern),
-        ("gradient", GroundTruthCategory.blacked_out),
+        ("black_area", GroundTruthCategory.blacked_out),
         ("mean_error", GroundTruthCategory.check_pattern),
     ],
 )
@@ -68,6 +68,8 @@ def test_noisy_frame_detection(video, ground_truth, noise_detection_method, nois
                 "see https://github.com/Aharoni-Lab/mio/pull/97"
             )
         global_config: DenoiseConfig = DenoiseConfig.from_id("denoise_example_mean_error")
+    elif noise_detection_method == "black_area":
+        global_config: DenoiseConfig = DenoiseConfig.from_id("denoise_example")
     else:
         raise ValueError("Invalid noise detection method")
 
@@ -95,7 +97,7 @@ def test_noisy_frame_detection(video, ground_truth, noise_detection_method, nois
         if previous_frame is None:
             previous_frame = frame
 
-        is_noisy, mask = detector.process_and_verify_frame(frame=frame)
+        is_noisy, mask = detector.find_invalid_area(frame=frame)
         if not is_noisy:
             previous_frame = frame
 

--- a/tests/test_process_video.py
+++ b/tests/test_process_video.py
@@ -20,7 +20,7 @@ class TestVideoProcessors(unittest.TestCase):
         denoise_config.noise_patch.enable = True
         denoise_config.noise_patch.output_result = True
 
-        processor = NoisePatchProcessor("denoise_example", denoise_config.noise_patch, self.width, self.height, self.test_dir)
+        processor = NoisePatchProcessor("denoise_example", denoise_config.noise_patch, self.test_dir)
         processed_frame = processor.process_frame(self.test_frame)
 
         self.assertIsInstance(processed_frame, np.ndarray)


### PR DESCRIPTION
The `_detect_black_pixels` looks if consecutive pixels in a row are black

` black_pixel_consecutive_threshold: 5 # If 5 consecutive pixels in a row are black, discard the frame
  black_pixel_value_threshold: 16 # Any pixel value ≤ 16 is considered "black"`
  
  those two parameters in denoise_examle.yaml decides how many consecutive pixels need to be black and what is defined as black (black pixels don't have a value of zero but when I checked was like 16)
  
 updated `detect_frame_with_noisy_buffer` to work with two methods simultaneously

added `test_frame_helper.py` to the test to also test the gradient method on blacked_out subcategory frames (since the gradient method now also incorporates finding black frames)
test all pass (except the xfail that jonny marked for obvious reasons)

curious about if this makes sense to you guys or if there are any major concerns!

example image in debug mode

<img width="1091" alt="Screenshot 2025-01-31 at 2 49 10 PM" src="https://github.com/user-attachments/assets/6531fc91-8639-4984-9b55-091c7269e30a" />

detects error in this image:
![Screenshot 2025-01-31 at 2 57 00 PM](https://github.com/user-attachments/assets/bf8ca0e9-6d32-49a2-8d1f-3a66224292f5)



<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--99.org.readthedocs.build/en/99/

<!-- readthedocs-preview miniscope-io end -->