### PR TITLE
Actually handle paths in `ConfigYAMLMixin.from_any`

### DIFF
--- a/mio/models/mixins.py
+++ b/mio/models/mixins.py
@@ -158,8 +158,6 @@ class ConfigYAMLMixin(BaseModel, YAMLMixin):
         elif valid_config_id(source):
             return cls.from_id(source)
         else:
-            from mio import Config
-
             source = Path(source)
             if source.suffix not in (".yaml", ".yml"):
                 raise ValueError(

--- a/mio/models/mixins.py
+++ b/mio/models/mixins.py
@@ -161,15 +161,19 @@ class ConfigYAMLMixin(BaseModel, YAMLMixin):
             from mio import Config
 
             source = Path(source)
-            if source.suffix in (".yaml", ".yml"):
-                if source.exists():
-                    # either relative to cwd or absolute
-                    return cls.from_yaml(source)
-                elif (
-                    not source.is_absolute()
-                    and (user_source := Config().config_dir / source).exists()
-                ):
-                    return cls.from_yaml(user_source)
+            if source.suffix not in (".yaml", ".yml"):
+                raise ValueError(
+                    "If not instantiating from a config id, "
+                    "must pass a relative or absolute path to a yaml file. "
+                    f"Got {source}"
+                )
+            if source.exists():
+                # either relative to cwd or absolute
+                return cls.from_yaml(source)
+            elif not source.is_absolute():
+                for config_source in cls.config_sources:
+                    if (user_source := config_source / source).exists():
+                        return cls.from_yaml(user_source)
 
         raise ValueError(
             f"Instance of config model {cls.__name__} could not be instantiated from "

--- a/mio/types.py
+++ b/mio/types.py
@@ -63,4 +63,6 @@ def valid_config_id(val: Any) -> TypeIs[ConfigID]:
     """
     Checks whether a string is a valid config id.
     """
+    if not isinstance(val, str):
+        return False
     return bool(re.fullmatch(CONFIG_ID_PATTERN, val))

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -77,7 +77,7 @@ def test_config_from_any(yaml_config, id, id_or_path, path, valid):
         assert loaded.child == instance.child
         assert isinstance(loaded.child, NestedModel)
     else:
-        with pytest.raises(KeyError, ValueError):
+        with pytest.raises((KeyError, ValueError)):
             MyModel.from_any(id_or_path)
 
     # and we should always be able to load an absolute path


### PR DESCRIPTION
@MarcelMB let me know that one couldn't pass an absolute (or any) path in the `-c` flag in the cli with this traceback (truncated)

```
  File “miniscope-io/mio/stream_daq.py”, line 103, in __init__
    self.config = StreamDevConfig.from_any(device_config)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “miniscope-io/mio/models/mixins.py”, line 158, in from_any
    elif valid_config_id(source):
         ^^^^^^^^^^^^^^^^^^^^^^^
  File “miniscope-io/mio/types.py”, line 66, in valid_config_id
    return bool(re.fullmatch(CONFIG_ID_PATTERN, val))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File “python3.11/re/__init__.py”, line 171, in fullmatch
    return _compile(pattern, flags).fullmatch(string)          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got ‘PosixPath’
```

Very simple, just a matter of checking for something being a string in the function that tests whether something is a valid ID string.

First committing correctly failing tests to demonstrate we're replicating the error and then the patch

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--102.org.readthedocs.build/en/102/

<!-- readthedocs-preview miniscope-io end -->