### PR TITLE
Expose hash video function to mio cli

### DIFF
--- a/docs/cli/hash.md
+++ b/docs/cli/hash.md
@@ -1,0 +1,7 @@
+# `hash`
+
+```{eval-rst}
+.. click:: mio.cli.util:hash
+    :prog: mio hash
+    :nested: full
+```

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -8,6 +8,7 @@ device
 stream
 update
 process
+hash
 ```
 
 Refer to the following page for details regarding ``stream_daq`` device config files.

--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -3,6 +3,7 @@
 ## Upcoming
 
 - [`#93`](https://github.com/Aharoni-Lab/mio/pull/93) - Add `mio config list` to display available configs
+- [`#103`](https://github.com/Aharoni-Lab/mio/pull/103) - Add `mio hash` to cli to hash video files
 
 ## 0.8.*
 

--- a/mio/cli/main.py
+++ b/mio/cli/main.py
@@ -8,6 +8,7 @@ from mio.cli.config import config
 from mio.cli.process import process
 from mio.cli.stream import stream
 from mio.cli.update import device, update
+from mio.cli.util import hash
 
 
 @click.group()
@@ -25,3 +26,4 @@ cli.add_command(update)
 cli.add_command(device)
 cli.add_command(config)
 cli.add_command(process)
+cli.add_command(hash)

--- a/mio/cli/util.py
+++ b/mio/cli/util.py
@@ -1,0 +1,23 @@
+"""
+Some random utility functions. This should be organized elsewhere but just throwing it here for now.
+"""
+
+from pathlib import Path
+
+import click
+
+from mio.utils import hash_video
+
+
+@click.command()
+@click.argument("path", type=click.Path(exists=True, dir_okay=False))
+def hash(path: str) -> None:
+    """
+    Hash a file
+    """
+
+    if Path(path).suffix in [".avi", ".mp4"]:
+        path = Path(path)
+        click.echo(hash_video(path))
+    else:
+        click.echo("Only video files are supported now.")


### PR DESCRIPTION
Tiny PR for exposing hash_video command to CLI

```bash
mio hash VIDEO_PATH
```

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--103.org.readthedocs.build/en/103/

<!-- readthedocs-preview miniscope-io end -->