### PR TITLE
Add `update_freq_mask` method

### DIFF
--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -175,15 +175,18 @@ class FreqencyMaskingConfig(BaseModel):
     )
     spatial_LPF_cutoff_radius: int = Field(
         default=...,
-        description="Radius for the spatial low pass filter cutoff in pixels.",
+        description="Default radius for the spatial low pass filter cutoff in pixels."
+        "This value will be used unless the value is modified using the update_freq_mask method.",
     )
     vertical_BEF_cutoff: int = Field(
         default=5,
-        description="Cutoff for the vertical band elimination filter in pixels.",
+        description="Cutoff for the vertical band elimination filter in pixels."
+        "This value will be used unless the value is modified using the update_freq_mask method.",
     )
     horizontal_BEF_cutoff: int = Field(
         default=0,
-        description="Cutoff for the horizontal band elimination filter in pixels.",
+        description="Cutoff for the horizontal band elimination filter in pixels."
+        "This value will be used unless the value is modified using the update_freq_mask method.",
     )
     output_result: bool = Field(
         default=False,

--- a/mio/process/frame_helper.py
+++ b/mio/process/frame_helper.py
@@ -449,13 +449,9 @@ class FrequencyMaskHelper(BaseSingleFrameHelper):
         A central circular region can be removed to allow low frequencies to pass.
 
         Parameters:
-        ----------
-        vertical_BEF_cutoff : int
-            Cutoff for the vertical band elimination filter in pixels.
-        horizontal_BEF_cutoff : int
-            Cutoff for the horizontal band elimination filter in pixels.
-        spatial_LPF_cutoff_radius : int
-            Radius for the spatial low pass filter cutoff in pixels.
+            vertical_BEF_cutoff (int): Cutoff for the vertical band elimination filter in px.
+            horizontal_BEF_cutoff (int): Cutoff for the horizontal band elimination filter in px.
+            spatial_LPF_cutoff_radius (int): Radius for the spatial low pass filter cutoff in px.
         """
         crow, ccol = self._height // 2, self._width // 2
 

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -305,6 +305,18 @@ class FreqencyMaskProcessor(BaseVideoProcessor):
         """
         return NamedVideo(name="freq_domain", video=self.freq_domain_frames)
 
+    def update_freq_mask(
+        self, vertical_BEF_cutoff: int, horizontal_BEF_cutoff: int, spatial_LPF_cutoff_radius: int
+    ) -> None:
+        """
+        Update the frequency mask.
+        """
+        self.freq_mask_helper.update_freq_mask(
+            vertical_BEF_cutoff=vertical_BEF_cutoff,
+            horizontal_BEF_cutoff=horizontal_BEF_cutoff,
+            spatial_LPF_cutoff_radius=spatial_LPF_cutoff_radius,
+        )
+
     def process_frame(self, input_frame: np.ndarray) -> Optional[np.ndarray]:
         """
         Process a single frame.


### PR DESCRIPTION
This PR adds a method for updating the frequency mask during processing. If we want to do adaptive frequency masking in the `mio process denoise` module, adding `freq_mask_processor.update_freq_mask(params)` right before the following code (which processes each frame in the `for` loop) should be most straightforward.
https://github.com/Aharoni-Lab/mio/blob/993617163700b87e851cbd2f6c58c46ec55edbc7/mio/process/video.py#L553

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--105.org.readthedocs.build/en/105/

<!-- readthedocs-preview miniscope-io end -->