### PR TITLE
Butter filter for mean intensity values

### DIFF
--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -22,8 +22,8 @@ noise_patch:
 frequency_masking:
   enable: true
   cast_float32: true
-  spatial_LPF_cutoff_radius: 15
-  vertical_BEF_cutoff: 2
+  spatial_LPF_cutoff_radius: 3
+  vertical_BEF_cutoff: 3
   horizontal_BEF_cutoff: 0
   output_mask: true
   output_result: true
@@ -35,8 +35,8 @@ minimum_projection:
   output_min_proj: true
 interactive_display:
   show_videos: true
-  start_frame: 40
-  end_frame: 140
+  start_frame: 0
+  end_frame: 500
   display_freq_mask: true
 end_frame: -1 #-1 means all frames
 output_result: true
@@ -44,7 +44,7 @@ output_dir: user_data/output
 butter_filter:
   enable: true
   plot: true
-  order: 3
+  order: 6
   cutoff_frequency: 3
   sampling_rate: 20
   plot_start_frame: 40

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -41,3 +41,11 @@ interactive_display:
 end_frame: -1 #-1 means all frames
 output_result: true
 output_dir: user_data/output
+butter_filter:
+  enable: true
+  plot: true
+  order: 3
+  cutoff_frequency: 3
+  sampling_rate: 20
+  plot_start_frame: 40
+  plot_end_frame: 140

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -22,7 +22,7 @@ noise_patch:
 frequency_masking:
   enable: true
   cast_float32: true
-  spatial_LPF_cutoff_radius: 3
+  spatial_LPF_cutoff_radius: 2
   vertical_BEF_cutoff: 3
   horizontal_BEF_cutoff: 0
   output_mask: true
@@ -47,5 +47,6 @@ butter_filter:
   order: 6
   cutoff_frequency: 3
   sampling_rate: 20
-  plot_start_frame: 40
-  plot_end_frame: 140
+  plot_start_frame: 0
+  plot_end_frame: 600
+  

--- a/mio/models/frames.py
+++ b/mio/models/frames.py
@@ -112,7 +112,7 @@ class NamedVideo(NamedBaseFrame):
         output_dir = output_path.parent
         base_name = output_path.stem
 
-        if suffix:
+        if suffix and not base_name.endswith(self.name):
             base_name = f"{base_name}_{self.name}"
 
         full_output_path = (output_dir / base_name).with_suffix(".avi")

--- a/mio/models/frames.py
+++ b/mio/models/frames.py
@@ -106,27 +106,31 @@ class NamedVideo(NamedBaseFrame):
             return
 
         output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
 
-        # Add output_ prefix to the filename
-        filename = f"output_{self.name}" if not self.name.startswith("output_") else self.name
-        output_path = output_path / filename
+        # Get the directory and base filename parts
+        output_dir = output_path.parent
+        base_name = output_path.stem
 
         if suffix:
-            output_path = output_path.with_name(output_path.stem + f"_{self.name}")
+            base_name = f"{base_name}_{self.name}"
+
+        full_output_path = (output_dir / base_name).with_suffix(".avi")
 
         if not all(isinstance(frame, np.ndarray) for frame in self.video):
             raise ValueError("Not all frames are numpy arrays.")
 
         writer = VideoWriter.init_video(
-            path=output_path.with_suffix(".avi"),
+            path=full_output_path,
             width=self.video[0].shape[1],
             height=self.video[0].shape[0],
             fps=fps,
+            fourcc="XVID",
         )
 
         logger.info(
-            f"Writing video to {output_path}.avi:"
-            f"{self.video[0].shape[1]}x{self.video[0].shape[0]}"
+            f"Writing video to {full_output_path}:"
+            f" {self.video[0].shape[1]}x{self.video[0].shape[0]}"
         )
 
         try:

--- a/mio/models/frames.py
+++ b/mio/models/frames.py
@@ -104,21 +104,31 @@ class NamedVideo(NamedBaseFrame):
         if self.video is None or self.video == []:
             logger.warning(f"No frame data provided for {self.name}. Skipping export.")
             return
+
         output_path = Path(output_path)
+
+        # Add output_ prefix to the filename
+        filename = f"output_{self.name}" if not self.name.startswith("output_") else self.name
+        output_path = output_path / filename
+
         if suffix:
             output_path = output_path.with_name(output_path.stem + f"_{self.name}")
+
         if not all(isinstance(frame, np.ndarray) for frame in self.video):
             raise ValueError("Not all frames are numpy arrays.")
+
         writer = VideoWriter.init_video(
             path=output_path.with_suffix(".avi"),
             width=self.video[0].shape[1],
             height=self.video[0].shape[0],
             fps=fps,
         )
+
         logger.info(
             f"Writing video to {output_path}.avi:"
             f"{self.video[0].shape[1]}x{self.video[0].shape[0]}"
         )
+
         try:
             for frame in self.video:
                 picture = cv2.cvtColor(frame, cv2.COLOR_GRAY2BGR)

--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -223,6 +223,18 @@ class InteractiveDisplayConfig(BaseModel):
     )
 
 
+class ButterworthFilterConfig(BaseModel):
+    """Configuration for Butterworth lowpass filter."""
+
+    enable: bool = Field(default=False, description="Enable Butterworth filtering")
+    order: int = Field(default=3, description="Filter order")
+    cutoff_frequency: float = Field(default=3.0, description="Cutoff frequency in Hz")
+    sampling_rate: float = Field(default=20.0, description="Sampling rate in Hz")
+    plot: bool = Field(default=False, description="Plot the filtered data")
+    plot_start_frame: Optional[int] = Field(default=None, description="Start frame for plotting")
+    plot_end_frame: Optional[int] = Field(default=None, description="End frame for plotting")
+
+
 class DenoiseConfig(MiniscopeConfig, ConfigYAMLMixin):
     """
     Configuration for denoising a video.
@@ -255,4 +267,7 @@ class DenoiseConfig(MiniscopeConfig, ConfigYAMLMixin):
     output_dir: Optional[str] = Field(
         default=None,
         description="Directory to save the output video streams and frames.",
+    )
+    butter_filter: ButterworthFilterConfig = Field(
+        default_factory=ButterworthFilterConfig, description="Configuration for Butterworth filter"
     )

--- a/mio/process/frame_helper.py
+++ b/mio/process/frame_helper.py
@@ -480,3 +480,16 @@ class FrameSplitter:
             pixel_index += px_per_buffer
         logger.debug(f"Split shape: {buffer_shape}")
         return buffer_shape
+
+
+def mean_intensity(frame: np.ndarray) -> float:
+    """
+    Calculate the mean pixel intensity for a frame.
+
+    Parameters:
+        frame (np.ndarray): The frame whose mean intensity is to be calculated
+                           on filtered data (broken frames replaced, spatial mask filter).
+    Returns:
+        float: The mean intensity of the frame.
+    """
+    return frame.mean()

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -91,7 +91,7 @@ class BaseVideoProcessor:
         if self.output_enable:
             logger.info(f"Exporting {self.name} video to {self.output_dir}")
             self.output_named_video.export(
-                output_path=self.output_dir / "output",
+                output_path=self.output_dir / self.name,
                 fps=20,
                 suffix=True,
             )

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -577,7 +577,10 @@ class ButterworthProcessor(BaseVideoProcessor):
             filtered_frames = self.apply_filter_to_frames(filtered_data)
             if filtered_frames:
                 logger.info("Saving Butterworth filtered video")
-                output_video = NamedVideo(name=self.name, video=filtered_frames)
+                output_video = NamedVideo(
+                    name=self.name,  # Remove "output_" prefix to match other processors
+                    video=filtered_frames,
+                )
                 output_video.export(self.output_dir)
             else:
                 logger.warning("No frames to save after Butterworth filtering")

--- a/mio/process/video.py
+++ b/mio/process/video.py
@@ -572,7 +572,6 @@ class ButterworthProcessor(BaseVideoProcessor):
         logger.info(f"Processing {len(self.frames)} frames with Butterworth filter")
         filtered_data = self.apply_filter()
         if len(filtered_data) > 0:
-
             np.save(self.output_dir / f"{self.name}_filtered_intensity.npy", filtered_data)
 
             filtered_frames = self.apply_filter_to_frames(filtered_data)
@@ -582,6 +581,9 @@ class ButterworthProcessor(BaseVideoProcessor):
                 output_video.export(self.output_dir)
             else:
                 logger.warning("No frames to save after Butterworth filtering")
+
+            if self.config.plot:
+                self.plot_filtered_data(filtered_data)
 
     def plot_filtered_data(self, filtered_data: np.ndarray) -> None:
         """Plot the original and filtered intensity data."""
@@ -613,13 +615,21 @@ class ButterworthProcessor(BaseVideoProcessor):
         plt.ylabel("Mean Intensity")
         plt.grid(True, alpha=0.3)
         plt.legend()
-
         plt.savefig(
             self.output_dir / f"{self.name}_intensity_plot.png", dpi=300, bbox_inches="tight"
         )
 
         if plt.get_backend() != "agg":
-            plt.show()
+            plt.savefig("temp_plot.png")  # Save temporarily
+            plot_img = cv2.imread("temp_plot.png")
+            cv2.imshow("Butterworth Filter Plot", plot_img)
+            while True:
+                if cv2.waitKey(1) == 27:  # Wait for ESC key
+                    break
+            cv2.destroyAllWindows()
+            cv2.waitKey(1)  # Extra waitKey to properly close the window
+            Path("temp_plot.png").unlink()  # Remove temporary file
+
         plt.close()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ documentation = "https://miniscope-io.readthedocs.io/"
 
 [project.optional-dependencies]
 plot = ["matplotlib>=3.9.2"]
+signal = [
+    "scipy>=1.10.0",  # For Butterworth filter
+]
 tests = [
     "pytest>=8.2.2",
     "pytest-cov>=5.0.0",

--- a/tests/test_models/test_model_frames.py
+++ b/tests/test_models/test_model_frames.py
@@ -5,15 +5,18 @@ from pathlib import Path
 
 from mio.models.frames import NamedFrame, NamedVideo
 
+
 class TestNamedFrame(unittest.TestCase):
 
     def setUp(self):
         # Create a single frame (image) and a list of frames (video)
         self.image_frame = np.random.randint(0, 256, (100, 100), dtype=np.uint8)
-        self.video_frames = [np.random.randint(0, 256, (100, 100), dtype=np.uint8) for _ in range(10)]
+        self.video_frames = [
+            np.random.randint(0, 256, (100, 100), dtype=np.uint8) for _ in range(10)
+        ]
         self.name = "test"
 
-    @patch('cv2.imwrite')
+    @patch("cv2.imwrite")
     def test_export_image_frame(self, mock_imwrite):
         # Create instance of NamedFrame with a single image
         named_frame = NamedFrame(name=self.name, frame=self.image_frame)
@@ -22,7 +25,7 @@ class TestNamedFrame(unittest.TestCase):
         # Check that cv2.imwrite was called correctly
         mock_imwrite.assert_called_once_with("output_path_test.png", self.image_frame)
 
-    @patch('mio.models.frames.VideoWriter.init_video')
+    @patch("mio.models.frames.VideoWriter.init_video")
     def test_export_video_frame(self, mock_init_video):
         # Create a mock writer instance
         mock_writer = MagicMock()
@@ -38,14 +41,15 @@ class TestNamedFrame(unittest.TestCase):
             path=Path("output_path_test.avi"),
             width=self.video_frames[0].shape[1],
             height=self.video_frames[0].shape[0],
-            fps=20
+            fps=20,
+            fourcc="XVID",
         )
 
         # Check that the writer's write method was called for each frame
         self.assertEqual(mock_writer.write.call_count, len(self.video_frames))
 
-    @patch('cv2.imwrite')
-    @patch('mio.models.frames.VideoWriter.init_video')
+    @patch("cv2.imwrite")
+    @patch("mio.models.frames.VideoWriter.init_video")
     def test_invalid_frame_type_raises_exception(self, mock_init_video, mock_imwrite):
         # Test with an invalid type (e.g., integer)
         with self.assertRaises(ValueError):
@@ -61,5 +65,6 @@ class TestNamedFrame(unittest.TestCase):
         mock_imwrite.assert_not_called()
         mock_init_video.assert_not_called()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Correction for fluctuations of the brightness of the entire field of view

I think its pretty straightforward and can be easily merged. The filter is not absolutely necessary but would make the calcium traces hopefully a bit noisy (need to test this better)

- calculate the mean pixel intensity for every frame

- apply a butter low pass filter to mean intensity over time

- creates a figure using start_frame to end_frame config settings, showing raw data and butter filtered data to visually assess if the filter resembles the data

after pressing 'Esc' script continues running


this filter is applied to the already spatial mask-filtered data (if enabled)
similar method used in Daniels notebook from v4 Miniscope
ipynb notebook
he used it to: 'correct the other source of V4 Miniscope noise. This is a fast, ~+3Hz fluctuation of the brightness'

I also saw some higher frequency noise on the calcium traces of the wireless miniscope

![invivo-20241203-1-003_trim9min_butter_filter_intensity_plot](https://github.com/user-attachments/assets/1e073d27-ff21-44f2-98b1-bcd6c9757228)



<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--107.org.readthedocs.build/en/107/

<!-- readthedocs-preview miniscope-io end -->