### PR TITLE
Make `config_sources` a classmethod rather than a class property

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,12 +20,12 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,14 +42,13 @@ def mock_config_source(monkeypatch_session):
     """
     Add the `tests/data/config` directory to the config sources for the entire testing session
     """
-    current_sources = ConfigYAMLMixin.config_sources
+    current_sources = ConfigYAMLMixin.config_sources()
 
-    @classmethod
-    @property
     def _config_sources(cls: type[ConfigYAMLMixin]) -> list[Path]:
+        nonlocal current_sources
         return [CONFIG_DIR, *current_sources]
 
-    monkeypatch_session.setattr(ConfigYAMLMixin, "config_sources", _config_sources)
+    monkeypatch_session.setattr(ConfigYAMLMixin, "config_sources", classmethod(_config_sources))
 
 
 @pytest.fixture()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -52,14 +52,13 @@ def tmp_config_source(tmp_path, monkeypatch) -> Path:
 
     path = tmp_path / "configs"
     path.mkdir(exist_ok=True)
-    current_sources = ConfigYAMLMixin.config_sources
+    current_sources = ConfigYAMLMixin.config_sources()
 
-    @classmethod
-    @property
     def _config_sources(cls: type[ConfigYAMLMixin]) -> list[Path]:
+        nonlocal current_sources
         return [path, *current_sources]
 
-    monkeypatch.setattr(ConfigYAMLMixin, "config_sources", _config_sources)
+    monkeypatch.setattr(ConfigYAMLMixin, "config_sources", classmethod(_config_sources))
     return path
 
 

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -62,6 +62,12 @@ def test_config_from_id(yaml_config, id, path, valid):
             Path("configs/nested/path/config.yaml"),
             True,
         ),
+        (
+            "nested-path",
+            "nested-path",
+            Path("configs/nested/path/config.yaml"),
+            True,
+        ),
         ("not-valid", Path("not_in_dir/config.yaml"), Path("not_in_dir/config.yaml"), False),
     ],
 )
@@ -82,6 +88,15 @@ def test_config_from_any(yaml_config, id, id_or_path, path, valid):
 
     # and we should always be able to load an absolute path
     _ = MyModel.from_yaml(abs_path)
+
+
+def test_config_sources():
+    """
+    config_sources should return a list of paths
+    """
+    paths = ConfigYAMLMixin.config_sources()
+    assert len(paths) > 0
+    assert all([isinstance(p, Path) for p in paths])
 
 
 def test_roundtrip_to_from_yaml(tmp_config_source):


### PR DESCRIPTION
python 3.13 removed the ability to use `@classmethod`s and `@property` together - https://docs.python.org/3.13/library/functions.html#classmethod

This causes a bug when using `id`s to load configs like:

```
>       globs = [src.rglob("*.y*ml") for src in cls.config_sources]
E       TypeError: 'method' object is not iterable
```

so this is just a PR to switch it to being a classmethod. 

first committing updated ci action that tests against 3.13 to confirm failure, then committing fix.

- confirmed correctly failing in python 3.13 only - https://github.com/Aharoni-Lab/mio/actions/runs/13478817474?pr=109
- confirmed after fix no longer failing - https://github.com/Aharoni-Lab/mio/actions/runs/13478866148?pr=109

While refactoring the method, i noticed that usages were not being detected correctly by pycharm. this was because of the generic TypeVar i was using incorrectly rather than the `Self` annotation, which is the correct annotation for classmethods that behave like constructors of subclasses, so i also fixed that.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--109.org.readthedocs.build/en/109/

<!-- readthedocs-preview miniscope-io end -->