### PR TITLE
Separate buffer-splitting in `_fpga_recv` into a generator function

### DIFF
--- a/mio/devices/mocks.py
+++ b/mio/devices/mocks.py
@@ -10,8 +10,14 @@ Not to be considered part of the public interface of mio <3
 # ruff: noqa: D102
 
 import os
+import sys
 from pathlib import Path
 from typing import Dict, Optional
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
 
 from mio.exceptions import EndOfRecordingException
 
@@ -32,7 +38,12 @@ class okDevMock:
     this mock is to be used within a separate process.
     """
 
-    def __init__(self, serial_id: str = ""):
+    def __init__(
+        self,
+        read_length: int,
+        serial_id: str = "",
+    ):
+        self.read_length = read_length
         self.serial_id = serial_id
         self.bit_file: Optional[Path] = None
 
@@ -60,7 +71,12 @@ class okDevMock:
         assert Path(bit_file).exists()
         self.bit_file = Path(bit_file)
 
-    def read_data(self, length: int, addr: int = 0xA0, blockSize: int = 16) -> bytearray:
+    def read_data(
+        self, length: int | None = None, addr: int = 0xA0, blockSize: int = 16
+    ) -> bytearray:
+        if length is None:
+            length = self.read_length
+
         if self._buffer_position >= len(self._buffer):
             # Error if called after we have returned the last data
             raise EndOfRecordingException("End of sample buffer")
@@ -72,3 +88,12 @@ class okDevMock:
 
     def set_wire(self, addr: int, val: int) -> None:
         self._wires[addr] = val
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        try:
+            return self.read_data()
+        except EndOfRecordingException as e:
+            raise StopIteration() from e

--- a/mio/devices/mocks.py
+++ b/mio/devices/mocks.py
@@ -72,7 +72,7 @@ class okDevMock:
         self.bit_file = Path(bit_file)
 
     def read_data(
-        self, length: int | None = None, addr: int = 0xA0, blockSize: int = 16
+        self, length: Optional[int] = None, addr: int = 0xA0, blockSize: int = 16
     ) -> bytearray:
         if length is None:
             length = self.read_length

--- a/mio/devices/opalkelly.py
+++ b/mio/devices/opalkelly.py
@@ -3,6 +3,7 @@ Interfaces for OpalKelly (model number?) FPGAs
 """
 
 import sys
+from typing import Optional
 
 if sys.version_info < (3, 11):
     from typing_extensions import Self
@@ -60,7 +61,7 @@ class okDev(ok.okCFrontPanel):
         ret = self.ResetFPGA()
 
     def read_data(
-        self, length: int | None = None, addr: int = 0xA0, blockSize: int = 16
+        self, length: Optional[int] = None, addr: int = 0xA0, blockSize: int = 16
     ) -> bytearray:
         """
         Read a buffer's worth of data

--- a/mio/devices/opalkelly.py
+++ b/mio/devices/opalkelly.py
@@ -2,6 +2,13 @@
 Interfaces for OpalKelly (model number?) FPGAs
 """
 
+import sys
+
+if sys.version_info < (3, 11):
+    from typing_extensions import Self
+else:
+    from typing import Self
+
 from mio.exceptions import (
     DeviceConfigurationError,
     DeviceOpenError,
@@ -22,9 +29,10 @@ class okDev(ok.okCFrontPanel):
 
     """
 
-    def __init__(self, serial_id: str = ""):
+    def __init__(self, read_length: int, serial_id: str = ""):
         super().__init__()
         self.logger = init_logger("okDev")
+        self.read_length = read_length
         ret = self.OpenBySerial("")
         if ret != self.NoError:
             raise DeviceOpenError(f"Cannot open device: {serial_id}")
@@ -51,7 +59,9 @@ class okDev(ok.okCFrontPanel):
         )
         ret = self.ResetFPGA()
 
-    def read_data(self, length: int, addr: int = 0xA0, blockSize: int = 16) -> bytearray:
+    def read_data(
+        self, length: int | None = None, addr: int = 0xA0, blockSize: int = 16
+    ) -> bytearray:
         """
         Read a buffer's worth of data
 
@@ -63,6 +73,8 @@ class okDev(ok.okCFrontPanel):
         Returns:
             :class:`bytearray`
         """
+        if length is None:
+            length = self.read_length
         buf = bytearray(length)
         ret = self.ReadFromBlockPipeOut(addr, data=buf, blockSize=blockSize)
         if ret < 0:
@@ -87,3 +99,9 @@ class okDev(ok.okCFrontPanel):
         ret = self.UpdateWireIns()
         if ret != self.NoError:
             raise DeviceConfigurationError(f"Wire update failed: {ret}")
+
+    def __iter__(self) -> Self:
+        return self
+
+    def __next__(self) -> bytes:
+        return self.read_data()

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -826,9 +826,9 @@ def iter_buffers(
     while True:
         try:
             buf = next(source)
-        except (EndOfRecordingException, KeyboardInterrupt) as e:
+        except (EndOfRecordingException, KeyboardInterrupt, StopIteration):
             logger.debug("Got end of recording exception, breaking")
-            raise StopIteration() from e
+            return
         except StreamReadError:
             logger.exception("Read failed, continuing")
             # It might be better to choose continue or break with a continuous flag

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -847,7 +847,7 @@ def iter_buffers(
                     buf_start + len(preamble),
                     buf_stop + len(preamble),
                 )
-            yield buf[buf_start:buf_stop].tobytes()
+            yield cur_buffer[buf_start:buf_stop].tobytes()
 
         if pre_pos:
             cur_buffer = cur_buffer[pre_pos[-1] :]

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -807,7 +807,7 @@ def iter_buffers(
     preamble: Bits,
     pre_first: bool = True,
     capture_binary: Optional[Path] = None,
-) -> Generator[bytes]:
+) -> Generator[bytes, None, None]:
     """
     Given some iterator that yields bytes (like a camera device),
     yield buffers from that iterator as `bytes` objects

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -8,6 +8,7 @@ import os
 import queue
 import sys
 import time
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any, Callable, Generator, List, Literal, Optional, Tuple, Union
 
@@ -258,12 +259,12 @@ class StreamDaq:
             self.logger.info("Close serial port")
             sys.exit(1)
 
-    def _init_okdev(self, BIT_FILE: Path) -> Union[okDev, okDevMock]:
+    def _init_okdev(self, BIT_FILE: Path, read_length: int) -> Union[okDev, okDevMock]:
         # FIXME: when multiprocessing bug resolved, remove this and just mock in tests
         if os.environ.get("PYTEST_CURRENT_TEST") or os.environ.get("STREAMDAQ_MOCKRUN"):
-            dev = okDevMock()
+            dev = okDevMock(read_length=read_length)
         else:
-            dev = okDev()
+            dev = okDev(read_length=read_length)
 
         dev.upload_bit(str(BIT_FILE))
         dev.set_wire(0x00, 0b0010)
@@ -324,50 +325,26 @@ class StreamDaq:
             raise RuntimeError(f"Configured to use bitfile at {BIT_FILE} but no such file exists")
 
         # set up fpga devices
-        dev = self._init_okdev(BIT_FILE)
+        dev = self._init_okdev(BIT_FILE, read_length)
 
         # read loop
-        cur_buffer = BitArray()
         pre = Bits(self.preamble)
         if self.config.reverse_header_bits:
             pre = pre[::-1]
 
         locallogs.debug("Starting capture")
         try:
-            while 1:
+            for buf in iter_buffers(
+                dev, preamble=pre, pre_first=pre_first, capture_binary=capture_binary
+            ):
                 try:
-                    buf = dev.read_data(read_length)
-                except (EndOfRecordingException, KeyboardInterrupt):
-                    locallogs.debug("Got end of recording exception, breaking")
-                    break
-                except StreamReadError:
-                    locallogs.exception("Read failed, continuing")
-                    # It might be better to choose continue or break with a continuous flag
-                    continue
-
-                if capture_binary:
-                    with open(capture_binary, "ab") as file:
-                        file.write(buf)
-
-                dat = BitArray(buf)
-                cur_buffer = cur_buffer + dat
-                pre_pos = list(cur_buffer.findall(pre))
-                for buf_start, buf_stop in zip(pre_pos[:-1], pre_pos[1:]):
-                    if not pre_first:
-                        buf_start, buf_stop = (
-                            buf_start + len(self.preamble),
-                            buf_stop + len(self.preamble),
-                        )
-                    try:
-                        serial_buffer_queue.put(
-                            cur_buffer[buf_start:buf_stop].tobytes(),
-                            block=True,
-                            timeout=self.config.runtime.queue_put_timeout,
-                        )
-                    except queue.Full:
-                        locallogs.warning("Serial buffer queue full, skipping buffer.")
-                if pre_pos:
-                    cur_buffer = cur_buffer[pre_pos[-1] :]
+                    serial_buffer_queue.put(
+                        buf,
+                        block=True,
+                        timeout=self.config.runtime.queue_put_timeout,
+                    )
+                except queue.Full:
+                    locallogs.warning("Serial buffer queue full, skipping buffer.")
 
         finally:
             locallogs.debug("Quitting, putting sentinel in queue")
@@ -823,6 +800,57 @@ class StreamDaq:
                 writer.write(picture)
             except cv2.error as e:
                 self.logger.exception(f"Exception writing frame: {e}")
+
+
+def iter_buffers(
+    source: Iterator[bytes],
+    preamble: Bits,
+    pre_first: bool = True,
+    capture_binary: Optional[Path] = None,
+) -> Generator[bytes]:
+    """
+    Given some iterator that yields bytes (like a camera device),
+    yield buffers from that iterator as `bytes` objects
+    split by the `preamble` delimiter.
+
+    Args:
+        source (Iterator[bytes]): The iterator that yields bytes
+        preamble (Bits): The delimiter bit series to split buffers by
+        pre_first (bool | None): Whether preamble/header is returned
+            at the beginning of each buffer, by default True.
+        capture_binary (Path | None): save binary directly from the ``okDev`` to the supplied path,
+            if present.
+    """
+    logger = init_logger("streamDaq.iter_buffers")
+    cur_buffer = BitArray()
+    while True:
+        try:
+            buf = next(source)
+        except (EndOfRecordingException, KeyboardInterrupt) as e:
+            logger.debug("Got end of recording exception, breaking")
+            raise StopIteration() from e
+        except StreamReadError:
+            logger.exception("Read failed, continuing")
+            # It might be better to choose continue or break with a continuous flag
+            continue
+
+        if capture_binary:
+            with open(capture_binary, "ab") as file:
+                file.write(buf)
+
+        dat = BitArray(buf)
+        cur_buffer = cur_buffer + dat
+        pre_pos = list(cur_buffer.findall(preamble))
+        for buf_start, buf_stop in zip(pre_pos[:-1], pre_pos[1:]):
+            if not pre_first:
+                buf_start, buf_stop = (
+                    buf_start + len(preamble),
+                    buf_stop + len(preamble),
+                )
+            yield buf[buf_start:buf_stop].tobytes()
+
+        if pre_pos:
+            cur_buffer = cur_buffer[pre_pos[-1] :]
 
 
 # DEPRECATION: v0.3.0

--- a/mio/types.py
+++ b/mio/types.py
@@ -21,7 +21,7 @@ else:
 
 CONFIG_ID_PATTERN = r"[\w\-\/#]+"
 """
-Any alphanumeric string (\w), as well as
+Any alphanumeric string (\\w), as well as
 - ``-``
 - ``/``
 - ``#``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,8 +92,8 @@ lint.composite = [
     "black mio --diff"
 ]
 format.composite = [
+    "black mio",
     "ruff check --fix",
-    "black mio"
 ]
 
 [tool.pdm.build]

--- a/tests/test_devices/test_okdev.py
+++ b/tests/test_devices/test_okdev.py
@@ -1,0 +1,42 @@
+import pytest
+from pathlib import Path
+from mio.devices.mocks import okDevMock
+
+
+@pytest.fixture
+def _tmp_buffer(tmp_path: Path, set_okdev_input) -> bytes:
+    buffer = b"12345"
+    buffer_rep = b"12345" * 3
+    data_path = tmp_path / "data.bin"
+    with open(data_path, "wb") as f:
+        f.write(buffer_rep)
+    set_okdev_input(data_path)
+    return buffer
+
+
+def test_okdev_iter(_tmp_buffer: bytes) -> None:
+    """
+    sanity check that the __iter__ method for iteration on the okdev
+    does iter things
+    """
+    dev = okDevMock(read_length=5)
+    got_buffers = 0
+    for buf in dev:
+        assert buf == _tmp_buffer
+        got_buffers += 1
+    assert got_buffers == 3
+
+
+def test_okdev_next(_tmp_buffer: bytes) -> None:
+    """
+    the okDevMock.__next__ method (and by proxy okDev) does next things
+    """
+    dev = okDevMock(read_length=5)
+    buffers = []
+    buffers.append(next(dev))
+    buffers.append(next(dev))
+    buffers.append(next(dev))
+    with pytest.raises(StopIteration):
+        next(dev)
+
+    assert all([b == _tmp_buffer for b in buffers])

--- a/tests/test_stream_daq.py
+++ b/tests/test_stream_daq.py
@@ -213,7 +213,7 @@ def test_iter_buffers(read_size: int, tmp_path: Path):
     buffer = preamble_bytes + b"000"
     buffer_rep = buffer * n_reps
 
-    def _iterator(read_size: int) -> Generator[bytes]:
+    def _iterator(read_size: int) -> Generator[bytes, None, None]:
         nonlocal buffer_rep
         for i in range(0, len(buffer_rep), read_size):
             yield buffer_rep[i : i + read_size]

--- a/tests/test_stream_daq.py
+++ b/tests/test_stream_daq.py
@@ -9,9 +9,11 @@ import sys
 import signal
 import time
 from contextlib import contextmanager
+from bitstring import BitArray, Bits
+from typing import Generator
 
 from mio import BASE_DIR
-from mio.stream_daq import StreamDevConfig, StreamDaq
+from mio.stream_daq import StreamDevConfig, StreamDaq, iter_buffers
 from mio.utils import hash_video, hash_file
 from .conftest import DATA_DIR, CONFIG_DIR
 
@@ -195,3 +197,29 @@ def test_bitfile_names():
     pattern = re.compile(r"\.(?!bit$)|\s")
     for path in Path(BASE_DIR).glob("**/*.bit"):
         assert not pattern.search(str(path.name))
+
+
+@pytest.mark.parametrize("read_size", [3, 5, 7])
+def test_iter_buffers(read_size: int, tmp_path: Path):
+    """
+    iter_buffers should accept an iterator that yield bytes,
+    and split it by the preamble in a way that's insensitive to
+    the length of the read size
+    """
+    preamble_bytes = b"ab"
+    n_reps = 3
+
+    preamble = Bits(preamble_bytes)
+    buffer = preamble_bytes + b"000"
+    buffer_rep = buffer * n_reps
+
+    def _iterator(read_size: int) -> Generator[bytes]:
+        nonlocal buffer_rep
+        for i in range(0, len(buffer_rep), read_size):
+            yield buffer_rep[i : i + read_size]
+
+    got_buffers = []
+    for buf in iter_buffers(_iterator(read_size), preamble=preamble):
+        got_buffers.append(buf)
+
+    assert all([buf == buffer for buf in got_buffers])


### PR DESCRIPTION
Doing a live programming demo with @hsemwal , and for ~secret miniscope type~ we want to be able to test the pixel-wise and frame-wise processing of the data outside of the streamdaq class as we get it on its feet. since it's pretty hard to do that as is, this is a function-neutral change to just split out the iteration (as it would be done in the guts of the streamdaq) into a separate function.

i'm not sure how much we've actually said this on this repo, but all the pipelining stuff is getting split off into a separate package because it felt sort of absurd to do it all in `mio`, so until that's done, will be making smaller more targeted refactors.

should be *relatively* self explanatory, the one thing that might not be is making the stream device into an iterator with `__next__` and `__iter__` - we make the simplifying assumption here that we dont' want to change the read size mid-iteration in normal circumstances, but preserve the ability to do that by keeping the `length` param in the `okDev.read_data` method as optional. that lets us make the `iter_buffers` function generic: any iterator that yields bytes can be passed, and all it does it yields bytes after combining them and splitting by the `prefix`. if we want that to be more specialized (e.g. fuzzy prefix matching #42 ) we can make that into a class, but for now the generator is a way to have a tiny bit of state in a predictable way.

should be a function-neutral change, just making it to help ~secret miniscope type~ development in downstream branch while doing a programming lesson in small, self-contained PRs 

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--116.org.readthedocs.build/en/116/

<!-- readthedocs-preview miniscope-io end -->