### PR TITLE
Online frequency filter (stripe removal)

### DIFF
--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.8.*
+
+### 0.8.0 - 2025-09-19 - Realtime frequency filters for `stream` and test adjustments
+
+#### New Features
+- [`#121`](https://github.com/Aharoni-Lab/mio/pull/121) - Adds optional realtime frequency filtering to `mio stream`. Example usage:  
+  ```bash
+  mio stream capture -c wireless-200px -f remove_stripe_example
+  ```  
+  See the CLI docs for more details.
+
+#### Bugfixes
+- [`#121`](https://github.com/Aharoni-Lab/mio/pull/121) - The FFT/IFFT operation on videos sometimes produced values larger than the maximum of the type (e.g., 255 for `np.uint8`), resulting in bright artifacts. The frequency mask helper method now clips values before returning them to prevent this.
+
+#### Refactors
+- [`#121`](https://github.com/Aharoni-Lab/mio/pull/121) - `FrequencyMaskingConfig` is now a subclass of `MiniscopeConfig, ConfigYAMLMixin`, allowing it to be treated like other configs.
+
+#### Testing
+- [`#132`](https://github.com/Aharoni-Lab/mio/pull/132), [`#134`](https://github.com/Aharoni-Lab/mio/pull/134) - Pin macOS version to `macos-14` due to upstream issues in the Coveralls action.
+- [`#121`](https://github.com/Aharoni-Lab/mio/pull/121) - Add basic tests to ensure the method is invoked via CLI.
+
+
 ## 0.7.*
 
 ### 0.7.1 - 2025-08-07
@@ -35,7 +57,7 @@
 #### Testing
 
 - [`#125`](https://github.com/Aharoni-Lab/mio/pull/125) - Added a performance test with a generous
-  baseline to ensure that the streamdaq 
+  baseline to ensure that the streamdaq runs without significant delays.
 
 ### 0.7.0 - 2025-07-21 - Processing Module & Video Encoding Fixes
 PRs: [`#83`](https://github.com/Aharoni-Lab/mio/pull/83), [`#94`](https://github.com/Aharoni-Lab/mio/pull/94), [`#97`](https://github.com/Aharoni-Lab/mio/pull/97), [`#99`](https://github.com/Aharoni-Lab/mio/pull/99), [`#112`](https://github.com/Aharoni-Lab/mio/pull/112)

--- a/mio/cli/common.py
+++ b/mio/cli/common.py
@@ -4,7 +4,7 @@ Shared CLI utils
 
 from os import PathLike
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from click import Context, Parameter, ParamType
 
@@ -19,8 +19,8 @@ class ConfigIDOrPath(ParamType):
     name = "config-id-or-path"
 
     def convert(
-        self, value: str | PathLike[str], param: Optional[Parameter], ctx: Optional[Context]
-    ) -> str | Path:
+        self, value: Union[str, PathLike[str]], param: Optional[Parameter], ctx: Optional[Context]
+    ) -> Union[str, Path]:
         """
         If something looks like a yaml file, return as a path, otherwise return unchanged.
 

--- a/mio/cli/common.py
+++ b/mio/cli/common.py
@@ -5,7 +5,6 @@ Shared CLI utils
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
 
 from click import Context, Parameter, ParamType
 
@@ -19,7 +18,7 @@ class ConfigIDOrPath(ParamType):
 
     name = "config-id-or-path"
 
-    def convert(self, value: str, param: Optional[Parameter], ctx: Optional[Context]) -> str | Path:
+    def convert(self, value: str, param: Parameter | None, ctx: Context | None) -> str | Path:
         """
         If something looks like a yaml file, return as a path, otherwise return unchanged.
 

--- a/mio/cli/common.py
+++ b/mio/cli/common.py
@@ -2,9 +2,10 @@
 Shared CLI utils
 """
 
-from os import PathLike
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional
 
 from click import Context, Parameter, ParamType
 
@@ -18,9 +19,7 @@ class ConfigIDOrPath(ParamType):
 
     name = "config-id-or-path"
 
-    def convert(
-        self, value: Union[str, PathLike[str]], param: Optional[Parameter], ctx: Optional[Context]
-    ) -> Union[str, Path]:
+    def convert(self, value: str, param: Optional[Parameter], ctx: Optional[Context]) -> str | Path:
         """
         If something looks like a yaml file, return as a path, otherwise return unchanged.
 

--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -68,9 +68,8 @@ def _capture_options(fn: Callable) -> Callable:
         "-f",
         "--freq_mask_config",
         help="Path to frequency masking config YAML file",
-        type=click.Path(exists=True),
+        type=ConfigIDOrPath(),
     )(fn)
-
     return fn
 
 

--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -67,7 +67,10 @@ def _capture_options(fn: Callable) -> Callable:
     fn = click.option(
         "-f",
         "--freq_mask_config",
-        help="Path to frequency masking config YAML file",
+        help="Path to, or ID of frequency masking config YAML file - "
+        "applies frequency masking to the displayed video, "
+        "but preserves raw video and does not modify the video output written to disk "
+        "(apply postprocessing separately).",
         type=ConfigIDOrPath(),
     )(fn)
     return fn

--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Optional
 import click
 
 from mio.cli.common import ConfigIDOrPath
+from mio.models.process import FreqencyMaskingConfig
 from mio.stream_daq import StreamDaq
 
 
@@ -63,6 +64,12 @@ def _capture_options(fn: Callable) -> Callable:
         help="Display metadata in real time. \n"
         "**WARNING:** This is still an **EXPERIMENTAL** feature and is **UNSTABLE**.",
     )(fn)
+    fn = click.option(
+        "-f",
+        "--freq_mask_config",
+        help="Path to frequency masking config YAML file",
+        type=click.Path(exists=True),
+    )(fn)
 
     return fn
 
@@ -72,6 +79,7 @@ def _capture_options(fn: Callable) -> Callable:
 @_capture_options
 def capture(
     device_config: Path,
+    freq_mask_config: Optional[Path],
     output: Optional[Path],
     okwarg: Optional[dict],
     no_display: Optional[bool],
@@ -96,6 +104,11 @@ def capture(
         metadata_output = None
         binary_output = None
 
+    if freq_mask_config:
+        freq_mask_config = FreqencyMaskingConfig.from_any(freq_mask_config)
+    else:
+        freq_mask_config = None
+
     daq_inst.capture(
         source="fpga",
         video=video_output,
@@ -104,6 +117,7 @@ def capture(
         binary=binary_output,
         show_video=not no_display,
         show_metadata=metadata_display,
+        freq_mask_config=freq_mask_config,
     )
 
 

--- a/mio/cli/stream.py
+++ b/mio/cli/stream.py
@@ -4,7 +4,7 @@ CLI commands for running streamDaq
 
 import os
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import click
 
@@ -53,7 +53,6 @@ def _capture_options(fn: Callable) -> Callable:
         "passed as (potentially multiple) calls like\n\n"
         "mio stream capture -ok key1 val1 -ok key2 val2",
         multiple=True,
-        type=(str, Any),
     )(fn)
     fn = click.option("--no-display", is_flag=True, help="Don't show video in real time")(fn)
     fn = click.option("-b", "--binary_export", is_flag=True, help="Save binary to a .bin file")(fn)

--- a/mio/data/config/process/bpf_example.yml
+++ b/mio/data/config/process/bpf_example.yml
@@ -1,0 +1,11 @@
+id: bpf_example
+mio_model: mio.models.process.FreqencyMaskingConfig
+mio_version: 0.6.1
+enable: true
+cast_float32: true
+spatial_LPF_cutoff_radius: 15
+vertical_BEF_cutoff: 2
+horizontal_BEF_cutoff: 0
+output_mask: false
+output_result: false
+output_freq_domain: false

--- a/mio/data/config/process/denoise_example.yml
+++ b/mio/data/config/process/denoise_example.yml
@@ -20,6 +20,9 @@ noise_patch:
   output_diff: true
   output_noisy_frames: true
 frequency_masking:
+  id: frequency_masking_example
+  mio_model: mio.models.process.FreqencyMaskingConfig
+  mio_version: 0.6.1
   enable: true
   cast_float32: true
   spatial_LPF_cutoff_radius: 15

--- a/mio/data/config/process/denoise_example_mean_error.yml
+++ b/mio/data/config/process/denoise_example_mean_error.yml
@@ -20,6 +20,9 @@ noise_patch:
   output_diff: true
   output_noisy_frames: true
 frequency_masking:
+  id: frequency_masking_example_mean_error
+  mio_model: mio.models.process.FreqencyMaskingConfig
+  mio_version: 0.6.1
   enable: true
   spatial_LPF_cutoff_radius: 15
   vertical_BEF_cutoff: 2

--- a/mio/data/config/process/remove_stripe_example.yml
+++ b/mio/data/config/process/remove_stripe_example.yml
@@ -1,9 +1,9 @@
-id: bpf_example
+id: remove_stripe_example
 mio_model: mio.models.process.FreqencyMaskingConfig
 mio_version: 0.6.1
 enable: true
 cast_float32: true
-spatial_LPF_cutoff_radius: 15
+spatial_LPF_cutoff_radius: 5
 vertical_BEF_cutoff: 2
 horizontal_BEF_cutoff: 0
 output_mask: false

--- a/mio/models/process.py
+++ b/mio/models/process.py
@@ -154,7 +154,7 @@ class NoisePatchConfig(BaseModel):
     )
 
 
-class FreqencyMaskingConfig(BaseModel):
+class FreqencyMaskingConfig(MiniscopeConfig, ConfigYAMLMixin):
     """
     Configuration for frequency filtering.
     This includes a spatial low-pass filter and vertical and horizontal band elimination filters.

--- a/mio/process/frame_helper.py
+++ b/mio/process/frame_helper.py
@@ -395,7 +395,10 @@ class FrequencyMaskHelper(BaseSingleFrameHelper):
         fshift *= self.freq_mask
         f_ishift = np.fft.ifftshift(fshift)
         img_back = np.fft.ifft2(f_ishift)
-        img_back = np.abs(img_back)
+
+        # Clip value to valid range and convert back to uint8.
+        # Some cases get rounded up higher than 255.
+        img_back = np.clip(np.abs(img_back), 0, np.iinfo(np.uint8).max)
 
         return np.uint8(img_back)
 

--- a/tests/data/config/remove_stripe_example.yml
+++ b/tests/data/config/remove_stripe_example.yml
@@ -1,0 +1,11 @@
+id: test_remove_stripe_example
+mio_model: mio.models.process.FreqencyMaskingConfig
+mio_version: 0.6.1
+enable: true
+cast_float32: true
+spatial_LPF_cutoff_radius: 5
+vertical_BEF_cutoff: 2
+horizontal_BEF_cutoff: 0
+output_mask: false
+output_result: false
+output_freq_domain: false

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,7 +122,7 @@ def test_cli_capture(
     path_stem = tmp_path / "data"
     data_file = DATA_DIR / "stream_daq_test_fpga_raw_input_200px.bin"
     set_okdev_input(data_file)
-    args = ["--device_config", "test-wireless-200px", "--output", str(path_stem)]
+    args = ["--device_config", "test-wireless-200px", "--output", str(path_stem), "--no-display"]
 
     # bit of a ghost parameterization -
     # left as placeholder in case we want to test freq mask display

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,7 @@ def test_cli_config_user_path(set_env, set_user_yaml):
     ],
 )
 def test_cli_capture(
-    freq_mask_config: str | None,
+    freq_mask_config,
     video_hash: str,
     tmp_path,
     set_okdev_input,


### PR DESCRIPTION
Online (real-time) bandpass filtering integrated with the `stream` command.
```
mio stream capture -c wireless-200px -f remove_stripe_example
```
This only filters the video preview, leaving the file output as is.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview miniscope-io end -->