### PR TITLE
Fix csvwriter header alignment, fix writing duplicated header rows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Install FFmpeg on Ubuntu
         if: runner.os == 'Linux'
-        run: sudo apt-get install -y ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
 
       - name: Run tests
         uses: pavelzw/pytest-action@v2

--- a/README.md
+++ b/README.md
@@ -8,10 +8,12 @@
 
 Generic i/o interfaces for miniscopes.
 
-In alpha - Fuller README forthcoming.
+This software is currently in internal alpha development 
+and is not yet intended for production usage in live experiments.
+The software will be ready for public/external/production use after version `v1.0.0`.
 
-See the docs for now: https://miniscope-io.readthedocs.io/
-
+Fuller README forthcoming. 
+In the meantime, see the docs: https://miniscope-io.readthedocs.io/
 
 
 ## Licensing

--- a/docs/meta/changelog.md
+++ b/docs/meta/changelog.md
@@ -1,8 +1,43 @@
 # Changelog
 
-## 0.7 - Processing Module & Video Encoding Fixes
+## 0.7.*
 
-### 0.7.0 - 2024-07-21
+### 0.7.1 - 2025-08-07
+
+#### Bugfix
+
+- [`#125`](https://github.com/Aharoni-Lab/mio/pull/125) - If a device configuration caused the
+  `buffer_npix` method to not match the number of buffers per frame returned by the device,
+  frame headers would be duplicated when sent through the rest of the pipeline,
+  resulting in duplicate rows in the resulting csv file.
+  Behavior was fixed, and the warning was upgrade to a more explicit exception message
+  that is more informative about the nature of the problem
+
+#### Added
+
+- [`#125`](https://github.com/Aharoni-Lab/mio/pull/125) - the `BufferedCSVWriter` class now
+  takes an explicit list of values to use as the headers, and accepts dicts for rows that
+  match those headers. this makes for explicit alignment in produced tables,
+  ignoring extra values and filling missing values.
+- [`#117`](https://github.com/Aharoni-Lab/mio/pull/117) - A {class}`mio.plots.VideoPlotter`
+  class was added to display a list of videos together
+
+#### Refactor
+
+- [`#116`](https://github.com/Aharoni-Lab/mio/pull/116) - Continuing the process of
+  splitting up the {class}`mio.stream_daq.StreamDaq` class, the method for
+  iterating over an arbitrary-sized input buffer from a device, concatenating it,
+  and splitting it into buffers according to some `preamble` bytestring
+  was split into a {func}`mio.stream_daq.iter_buffers` generator function,
+  where the binary source of devices is now any iterator that yields bytestrings.
+  Corresponding `__iter__` methods were added to {class}`mio.devices.opalkelly.okDev`.
+
+#### Testing
+
+- [`#125`](https://github.com/Aharoni-Lab/mio/pull/125) - Added a performance test with a generous
+  baseline to ensure that the streamdaq 
+
+### 0.7.0 - 2025-07-21 - Processing Module & Video Encoding Fixes
 PRs: [`#83`](https://github.com/Aharoni-Lab/mio/pull/83), [`#94`](https://github.com/Aharoni-Lab/mio/pull/94), [`#97`](https://github.com/Aharoni-Lab/mio/pull/97), [`#99`](https://github.com/Aharoni-Lab/mio/pull/99), [`#112`](https://github.com/Aharoni-Lab/mio/pull/112)
 #### Changes
 - **Added video processing (denoising) module for neural recordings.** This module is currently for offline use with video files. Real-time integration with `streamDaq` is planned for a future update.

--- a/mio/io.py
+++ b/mio/io.py
@@ -188,7 +188,6 @@ class BufferedCSVWriter:
             keys that are not in `header` are ignored, and missing keys are `None`
         """
         row = [data.get(key) for key in self.header]
-        row = [int(value) if isinstance(value, np.generic) else value for value in row]
         self.buffer.append(row)
         if len(self.buffer) >= self.buffer_size:
             self.flush_buffer()

--- a/mio/io.py
+++ b/mio/io.py
@@ -6,7 +6,7 @@ import atexit
 import contextlib
 import csv
 from pathlib import Path
-from typing import Any, BinaryIO, Iterator, List, Literal, Optional, Tuple, Union, overload
+from typing import BinaryIO, Iterator, Literal, Optional, Tuple, Union, overload
 
 import cv2
 import numpy as np
@@ -147,6 +147,9 @@ class BufferedCSVWriter:
     ----------
     file_path : Union[str, Path]
         The file path for the CSV file.
+    headers : list[str]
+        Headers for csv - determine the order of columns and allowable values
+        passed to :meth:`.append`
     buffer_size : int, optional
         The number of rows to buffer before writing to the file (default is 100).
 
@@ -160,26 +163,33 @@ class BufferedCSVWriter:
         The buffer for storing rows before writing.
     """
 
-    def __init__(self, file_path: Union[str, Path], buffer_size: int = 100):
+    def __init__(self, file_path: Union[str, Path], header: list[str], buffer_size: int = 100):
         self.file_path: Path = Path(file_path)
+        self.header = header
         self.buffer_size = buffer_size
         self.buffer = []
         self.logger = init_logger("BufferedCSVWriter")
 
+        # write header in first row
+        self.buffer.append(self.header)
+
         # Ensure the buffer is flushed when the program exits
         atexit.register(self.flush_buffer)
 
-    def append(self, data: List[Any]) -> None:
+    def append(self, data: dict) -> None:
         """
         Append data (as a list) to the buffer.
 
         Parameters
         ----------
-        data : List[Any]
+        data : dict
             The data to be appended.
+            Rows are constructed and columns are ordered according to `header` -
+            keys that are not in `header` are ignored, and missing keys are `None`
         """
-        data = [int(value) if isinstance(value, np.generic) else value for value in data]
-        self.buffer.append(data)
+        row = [data.get(key) for key in self.header]
+        row = [int(value) if isinstance(value, np.generic) else value for value in row]
+        self.buffer.append(row)
         if len(self.buffer) >= self.buffer_size:
             self.flush_buffer()
 

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -353,22 +353,19 @@ class StreamDaq:
                         locallogs,
                     )
                 except IndexError:
-                    locallogs.warning(
+                    locallogs.exception(
                         f"Frame {header_data.frame_num}; Buffer {header_data.buffer_count} "
                         f"(#{header_data.frame_buffer_count} in frame)\n"
                         f"Frame buffer count {header_data.frame_buffer_count} "
                         f"exceeds buffer number per frame {len(self.buffer_npix)}\n"
-                        f"Discarding buffer."
+                        f"Discarding buffer.\n"
+                        f"-- THERE IS AN ERROR IN YOUR CONFIGURATION CAUSING YOU TO LOSE DATA --\n"
+                        f"If you are seeing this emitted on every frame, "
+                        f"The device is sending more buffers per frame than expected based on "
+                        f"the configured frame width, height, and buffer size. "
+                        f"You must fix the configuration such that it matches the data being sent "
+                        f"by the device."
                     )
-                    if header_list:
-                        try:
-                            frame_buffer_queue.put(
-                                (None, header_list),
-                                block=True,
-                                timeout=self.config.runtime.queue_put_timeout,
-                            )
-                        except queue.Full:
-                            locallogs.warning("Frame buffer queue full, skipping frame.")
                     continue
 
                 # if first buffer of a frame

--- a/mio/stream_daq.py
+++ b/mio/stream_daq.py
@@ -304,9 +304,7 @@ class StreamDaq:
             reverse_payload_bytes=self.config.reverse_payload_bytes,
         )
 
-        header_data = StreamBufferHeader.from_format(
-            header.astype(int), self.header_fmt, construct=True
-        )
+        header_data = StreamBufferHeader.from_format(header.astype(int), self.header_fmt)
         header_data.adc_scaling = self.config.adc_scale
 
         return header_data, payload


### PR DESCRIPTION
@hsemwal reported an issue where the header metadata looked correct when it was being printed to stdout, but the csv being written was incorrect s.t. each buffer was being written multiple times....

<details>
<summary>expand/collapse example</summary>

|linked_list|frame_num                    |buffer_count|frame_buffer_count                           |write_buffer_count|dropped_buffer_count|timestamp|pixel_count|write_timestamp|battery_voltage_raw|input_voltage_raw|unix_time         |
|-----------|-----------------------------|------------|---------------------------------------------|------------------|--------------------|---------|-----------|---------------|-------------------|-----------------|------------------|
|11         |12821                        |102571      |3                                            |102570            |0                   |624079   |5072       |0              |0                  |0                |1753833136.014915 |
|30         |12823                        |102590      |6                                            |102587            |0                   |624183   |5072       |0              |0                  |0                |1753833136.0149791|
|11         |12821                        |102571      |3                                            |102570            |0                   |624079   |5072       |0              |0                  |0                |1753833136.02576  |
|30         |12823                        |102590      |6                                            |102587            |0                   |624183   |5072       |0              |0                  |0                |1753833136.0258172|
|31         |12823                        |102591      |7                                            |102588            |0                   |624185   |4496       |0              |0                  |0                |1753833136.025866 |
|11         |12821                        |102571      |3                                            |102570            |0                   |624079   |5072       |0              |0                  |0                |1753833136.21313  |
|30         |12823                        |102590      |6                                            |102587            |0                   |624183   |5072       |0              |0                  |0                |1753833136.213239 |
|31         |12823                        |102591      |7                                            |102588            |0                   |624185   |4496       |0              |0                  |0                |1753833136.213291 |
|0          |12824                        |102592      |0                                            |102592            |0                   |624218   |5072       |0              |0                  |0                |1753833136.213341 |
|1          |12824                        |102593      |1                                            |102593            |0                   |624220   |5072       |0              |0                  |0                |1753833136.213973 |
|2          |12824                        |102594      |2                                            |102593            |0                   |624222   |5072       |0              |0                  |0                |1753833136.2140312|
|3          |12824                        |102595      |3                                            |102594            |0                   |624225   |5072       |0              |0                  |0                |1753833136.214083 |
|4          |12824                        |102596      |4                                            |102594            |0                   |624227   |5072       |0              |0                  |0                |1753833136.214133 |
|1          |12824                        |102593      |1                                            |102593            |0                   |624220   |5072       |0              |0                  |0                |1753833136.217022 |
|2          |12824                        |102594      |2                                            |102593            |0                   |624222   |5072       |0              |0                  |0                |1753833136.217081 |
|3          |12824                        |102595      |3                                            |102594            |0                   |624225   |5072       |0              |0                  |0                |1753833136.217134 |
|4          |12824                        |102596      |4                                            |102594            |0                   |624227   |5072       |0              |0                  |0                |1753833136.217185 |
|5          |12824                        |102597      |5                                            |102595            |0                   |624230   |5072       |0              |0                  |0                |1753833136.217236 |
|1          |12824                        |102593      |1                                            |102593            |0                   |624220   |5072       |0              |0                  |0                |1753833136.219507 |
|2          |12824                        |102594      |2                                            |102593            |0                   |624222   |5072       |0              |0                  |0                |1753833136.2195652|
|3          |12824                        |102595      |3                                            |102594            |0                   |624225   |5072       |0              |0                  |0                |1753833136.2196171|
|4          |12824                        |102596      |4                                            |102594            |0                   |624227   |5072       |0              |0                  |0                |1753833136.219667 |
|5          |12824                        |102597      |5                                            |102595            |0                   |624230   |5072       |0              |0                  |0                |1753833136.219718 |
|6          |12824                        |102598      |6                                            |102595            |0                   |624232   |5072       |0              |0                  |0                |1753833136.219767 |
|1          |12824                        |102593      |1                                            |102593            |0                   |624220   |5072       |0              |0                  |0                |1753833136.2221272|
|2          |12824                        |102594      |2                                            |102593            |0                   |624222   |5072       |0              |0                  |0                |1753833136.222185 |
|3          |12824                        |102595      |3                                            |102594            |0                   |624225   |5072       |0              |0                  |0                |1753833136.2222688|
|4          |12824                        |102596      |4                                            |102594            |0                   |624227   |5072       |0              |0                  |0                |1753833136.2223349|
|5          |12824                        |102597      |5                                            |102595            |0                   |624230   |5072       |0              |0                  |0                |1753833136.222386 |
|6          |12824                        |102598      |6                                            |102595            |0                   |624232   |5072       |0              |0                  |0                |1753833136.2224362|
|7          |12824                        |102599      |7                                            |102596            |0                   |624234   |4496       |0              |0                  |0                |1753833136.222485 |
|1          |12824                        |102593      |1                                            |102593            |0                   |624220   |5072       |0              |0                  |0                |1753833136.304621 |
|2          |12824                        |102594      |2                                            |102593            |0                   |624222   |5072       |0              |0                  |0                |1753833136.304684 |
|3          |12824                        |102595      |3                                            |102594            |0                   |624225   |5072       |0              |0                  |0                |1753833136.3048398|
|4          |12824                        |102596      |4                                            |102594            |0                   |624227   |5072       |0              |0                  |0                |1753833136.304956 |
|5          |12824                        |102597      |5                                            |102595            |0                   |624230   |5072       |0              |0                  |0                |1753833136.305024 |
|6          |12824                        |102598      |6                                            |102595            |0                   |624232   |5072       |0              |0                  |0                |1753833136.305075 |
|7          |12824                        |102599      |7                                            |102596            |0                   |624234   |4496       |0              |0                  |0                |1753833136.305173 |
|8          |12825                        |102600      |0                                            |102600            |0                   |624266   |5072       |0              |0                  |0                |1753833136.3052218|

</details>

This was caused because we were passing the list of headers through when `buffer_npix` does not match the data being given by the device.

https://github.com/Aharoni-Lab/mio/blob/78870beec5edb11d67c1cec2fbf0d30aeab72572/mio/stream_daq.py#L355-L372

While trying to write the correctly failing test, i also noticed that the csv writer was just broken in general because there wasn't a good match between the header format and the writing of rows - the header row was coming from the `StreamBufferHeader` which is the class to contain *header data*, rather than the `StreamBufferHeaderFormat` which is the class that defines how the header is structured in the received buffers. 

as a result the headers were 
a) too short, so there were 12 columns of data but only 10 headers, and 
b) incorrect: the contents of each column were not actually the data they were supposed to be.

So i fixed that by making the `BufferedCSVWriter` have a `header` param (i don't think we ever want to write csvs that don't have a header row...). that defines the order and the columns, so then we pass individual rows as dictionaries - we only worry about the order of the columns at creation time, and that should determine the output structure of the whole csv. it should not be possible to accidentally break the table by passing an additional value to some row or not having some value.

---

the original bug is *not* a noisy signal bug, but an incorrect software or config problem - the `buffer_npix` is entirely determined by config, so if it doesn't match the number of buffers per frame being returned by the device, we should we made loudly aware of this.

First commit should be a correctly failing test confirming that i replicated the bug in the regression test, and then second should fix the test by simply not passing the header list multiple times into the queue.

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--125.org.readthedocs.build/en/125/

<!-- readthedocs-preview miniscope-io end -->