### PR TITLE
msus - test frame processing values with bright/dark sample

### DIFF
--- a/mio/utils.py
+++ b/mio/utils.py
@@ -4,7 +4,7 @@ The junk drawer my dogs
 
 import hashlib
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Iterator, Union
 
 import cv2
 
@@ -63,3 +63,13 @@ def hash_video(
         h.update(frame)  # type: ignore
 
     return h.hexdigest()
+
+def file_iter(path: Path, read_size: int) -> Iterator[bytes]:
+    """Iterator to read chunks of `read_size` bytes from a file"""
+    with open(path, "rb") as f:
+        while True:
+            data = f.read(read_size)
+            yield data
+            if len(data) != read_size:
+                break
+

--- a/mio/utils.py
+++ b/mio/utils.py
@@ -64,6 +64,7 @@ def hash_video(
 
     return h.hexdigest()
 
+
 def file_iter(path: Path, read_size: int) -> Iterator[bytes]:
     """Iterator to read chunks of `read_size` bytes from a file"""
     with open(path, "rb") as f:
@@ -72,4 +73,3 @@ def file_iter(path: Path, read_size: int) -> Iterator[bytes]:
             yield data
             if len(data) != read_size:
                 break
-

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -266,21 +266,14 @@ def set_config(request) -> Callable[[dict[str, Any]], Path]:
 def gs_raw_buffers() -> Generator[bytes, None, None]:
     from mio.stream_daq import iter_buffers
     from mio.devices.gs.config import GSDevConfig
+    from mio.utils import file_iter
     from .conftest import DATA_DIR
 
     gs_data = DATA_DIR / "gs_test_raw_15_brightDark.bin"
+
     config: GSDevConfig = GSDevConfig.from_id("MSUS-test")
 
-
-    def _file_iter(path, read_size):
-        with open(path, "rb") as f:
-            while True:
-                data = f.read(read_size)
-                yield data
-                if len(data) != read_size:
-                    break
-
-    file_iterator = _file_iter(gs_data, 2048)
+    file_iterator = file_iter(gs_data, 2048)
 
     return iter_buffers(file_iterator, Bits(config.preamble))
 

--- a/tests/test_gs/test_daq.py
+++ b/tests/test_gs/test_daq.py
@@ -48,3 +48,17 @@ def test_format_headers_raw(gs_raw_buffers):
     for pixel_arrays in frame_buffers.values():
         reconstructed = format_frame(pixel_arrays, config)
         assert reconstructed.shape == (config.frame_height, config.frame_width)
+
+
+@pytest.mark.parametrize(
+    "binary_input,thresh_low,thresh_high", [("gs_test_raw_15_brightDark.bin", 50, 256)]
+)
+def test_format_frame(binary_input, thresh_low, thresh_high):
+    """
+    Assuming the preceding steps work (tested elsewhere),
+    `format_frame` correctly reconstructs a 16-bit frame from a set of 1D pixel arrays.
+
+    We use a raw sample from the device where the sensor is covered for the first few frames,
+    and then exposed to bright light in the last few to generate "known input,"
+    since the device is not capable of generating a test pattern.
+    """

--- a/tests/test_gs/test_daq.py
+++ b/tests/test_gs/test_daq.py
@@ -1,9 +1,16 @@
+import pytest
 from collections import defaultdict
+
+from bitstring import Bits
+import numpy as np
+
 from mio.devices.gs.daq import format_frame
 from mio.devices.gs.testing import patterned_frame, frame_to_naneye_buffers, create_serialized_frame_data
 from mio.devices.gs.header import GSBufferHeaderFormat, GSBufferHeader
 from mio.devices.gs.config import GSDevConfig
-import numpy as np
+from mio.stream_daq import iter_buffers
+from mio.utils import file_iter
+from ..conftest import DATA_DIR
 
 
 def test_format_frames():
@@ -51,9 +58,9 @@ def test_format_headers_raw(gs_raw_buffers):
 
 
 @pytest.mark.parametrize(
-    "binary_input,thresh_low,thresh_high", [("gs_test_raw_15_brightDark.bin", 50, 256)]
+    "binary_input,thresh_low,thresh_high", [(DATA_DIR / "gs_test_raw_15_brightDark.bin", 50, 256)]
 )
-def test_format_frame(binary_input, thresh_low, thresh_high):
+def test_format_frame_with_known_input(binary_input, thresh_low, thresh_high):
     """
     Assuming the preceding steps work (tested elsewhere),
     `format_frame` correctly reconstructs a 16-bit frame from a set of 1D pixel arrays.
@@ -61,4 +68,36 @@ def test_format_frame(binary_input, thresh_low, thresh_high):
     We use a raw sample from the device where the sensor is covered for the first few frames,
     and then exposed to bright light in the last few to generate "known input,"
     since the device is not capable of generating a test pattern.
+
+    This test does not test the general correctness of `format_frame`,
+    like its error handling, correctness of shape, etc.
+    Here we are just testing the *values* of the frames - whether we get
+    correct pixel values (or as close as we can verify with such a coarse notion of known input)
     """
+    format = GSBufferHeaderFormat.from_id("gs-buffer-header")
+    config: GSDevConfig = GSDevConfig.from_id("MSUS-test")
+
+    iterator = file_iter(binary_input, 2048)
+    frame_buffers = defaultdict(list)
+
+    # collect pixel buffers by frame
+    for buffer in iter_buffers(iterator, Bits(config.preamble)):
+        header, pixels = GSBufferHeader.from_buffer(buffer, header_fmt=format, config=config)
+        header: GSBufferHeader
+        frame_buffers[header.frame_num].append(pixels)
+
+    # delete the first and last, we assume they are incomplete
+    del frame_buffers[min(frame_buffers.keys())]
+    del frame_buffers[max(frame_buffers.keys())]
+
+    frames = []
+    for frame_n in sorted(frame_buffers.keys()):
+        frames.append(format_frame(frame_buffers[frame_n], config))
+
+    # first frame should be dark, last frame should be bright
+    assert sum(frames[0] > thresh_low) == 0
+    assert sum(frames[-1] < thresh_high) == 0
+
+
+
+


### PR DESCRIPTION
add a test to use the bright/dark sample to assert that the frame processing is *basically correct* - we have a sample where the first frames are bright, and the later frames are dark(ish). so we just assert that basic fact about the data. 

it's *not* a very strict test for correctness, but it's a basic sanity check that we are getting bit/byte ordering "sort of right" 

<!-- readthedocs-preview miniscope-io start -->
----
📚 Documentation preview 📚: https://miniscope-io--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview miniscope-io end -->