### PR TITLE
Pin MacOS version for CI/CD

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'windows-latest', 'macos-13', 'macos-14', 'macos-15', 'macos-latest']
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:


### PR DESCRIPTION
The CI/CD workflow recently started failing even on previously passing commits. I suspect the cause is that the `macos-latest` image shifted from MacOS 14 to MacOS 15. Unfortunately, the logs from the last passing run have already expired, so I can’t confirm this.\

**Reference action run using multiple MacOS versions**: https://github.com/Aharoni-Lab/mio/actions/runs/17480012778

Observed results:
- **MacOS 15 (latest)**: fails at the coverage reporting step.  
- **MacOS 14**: everything works.  
- **MacOS 13**: fails at `pytest` (though it’s unclear if anyone is still using MacOS 13).  

The codebase shouldn't have OS *version*-dependent logic, so pinning coverage to MacOS 14 seems like a safe fix. That said, dropping MacOS 15 — which is likely what most people are actually using — is a little concerning, especially since the `pytest` outcomes differ across OS versions.

A possible compromise would be:
- Run **coverage on MacOS 14** (where it works reliably).  
- Run **tests on MacOS latest (15)**.  
However, I’m not sure whether this extra complexity is worth it, so I’d like to hear what @sneakers-the-rat thinks.